### PR TITLE
Open DOIs through preferred resolver

### DIFF
--- a/shortcuts/o/doi/1.txt
+++ b/shortcuts/o/doi/1.txt
@@ -1,1 +1,1 @@
-http://dx.doi.org/{%query}
+https://doi.org/{%query}


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update the resolver URL.

Cheers!