### PR TITLE
Use bootstrap color for namespaces

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -19,7 +19,7 @@ main .jumbotron {
       color: #444;
     }
     .namespace {
-      background: #aa2c30;
+      background: var(--red);
       color: white;
       padding: 0.2em;
     }


### PR DESCRIPTION
Fixes #88

Here is the browser support for CSS `var`: https://caniuse.com/css-variables