### PR TITLE
Deploy only when on main repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,7 @@
 name: Build and Deploy
-on:
-  push:
-    branches:
-      - master
-    workflow_dispatch:
+on: [push]
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +34,19 @@ jobs:
       - run: npm run compile-data
       - run: npm run test-unit
       - run: npm run test-calls
+      - uses: actions/upload-artifact@v4
+        with:
+          name: website
+          path: dist/public/
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.repository == 'trovu/trovu'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: website
+          path: dist/public
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: dist/public/


### PR DESCRIPTION
Als ich es geforkt hatte, ist erstmal die Pipeline gefailed, weil er versucht hatte es zu deployen. Daher sollte das angepasst werden.

Deploy sollte nur auf deinem Repo ausgeführt werden. Alternativ könnte man die Bedingung vielleicht darauf setzen, ob das Secret gesetzt ist.

Ich hab hier jetzt die Bedingung für den Branch rausgenommen, so dass das Builden auch auf anderen Branches passiert. Vielleicht sollte man wieder etwas einschränken, dass es entweder bei Push nach Master oder bei neuen Pull-Requests ausgeführt wird.

Du musst mal gucken, ob das mit den Artifacts übertragen in den nächsten Job funktioniert. Habe ich nicht getestet.