### PR TITLE
qr: Switch to quickchart.io for QR Code generation

### DIFF
--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -7076,14 +7076,13 @@ pz 1:
   tags:
   - old
 qr 1:
-  url: https://chart.apis.google.com/chart?cht=qr&chs=350x350&chl=<content>
-  title: QR Kaywa URL Barcode
+  url: https://quickchart.io/qr?size=350&text=<content>
+  title: QR Code
   tags:
-  - google
   - qr
   examples:
-  - arguments: http://www.serchilo.net
-    description: Create QR code for http://www.serchilo.net
+  - arguments: https://trovu.net
+    description: Create QR code for https://trovu.net
 qrdecoder 0:
   url: https://webqr.com
   title: QR-Decoder in the browser


### PR DESCRIPTION
Google deprecated it's old chart UI about 12 years ago, and finally shut it off
See https://groups.google.com/g/google-visualization-api/c/Pzzya6ed14g/m/QeJRTUyHAwAJ for discussion

Feel free to use another API - but Google's can't be used anymore.