### PR TITLE
feature | remove container when stoped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,19 @@
-# Define the name of the Docker image
 IMAGE_NAME=trovu-website
-
-# Define the container name
 CONTAINER_NAME=trovu-server
 
-# Build the Docker image
 build:
 	docker build -t $(IMAGE_NAME) .
 
-# Run the Docker container
 run:
-	docker run -d --name $(CONTAINER_NAME) -p 8081:8081 $(IMAGE_NAME)
+	docker run -d --name $(CONTAINER_NAME) -p 8081:8081 --rm $(IMAGE_NAME)
 
-# Stop the Docker container
 stop:
 	docker stop $(CONTAINER_NAME)
 
-# Remove the Docker container
 clean:
 	docker rm $(CONTAINER_NAME)
 	docker rmi $(IMAGE_NAME)
 
-# Rebuild the Docker image and container
 rebuild: clean build run
 
 .PHONY: build run stop clean rebuild


### PR DESCRIPTION
Improve current version of Makefile:
- Removed "extra" comments
- Added "--rm" flag so when the docker container is stop it's removed automatically.

This allows to use make run & make stop without having to manually remove the container.

With the current version, if you try make run & make stop you will get:
`docker: Error response from daemon: Conflict. The container name "/trovu-server" is already in use by container "1e2cbe018851451ed5aee9664a5a2e98a8e7ddd24fc9ca2c200d6be216be6602". ` (can be fixed by manually removing the container  or by using the ''clean'' command).

With this pull request the app will simply be up an down because the container will get re-created on each run.