### PR TITLE
Update Fedex shortcut for new URL, use <query>

### DIFF
--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -2743,7 +2743,7 @@ fedbugq 1:
   tags:
   - old
 fedex 1:
-  url: https://www.fedex.com/Tracking?tracknumbers=<track number>
+  url: https://www.fedex.com/fedextrack/?trknbr=<query>
   title: FedEx Tracking
   tags:
   - fedex

--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -2743,7 +2743,7 @@ fedbugq 1:
   tags:
   - old
 fedex 1:
-  url: https://www.fedex.com/fedextrack/?trknbr=<query>
+  url: https://www.fedex.com/fedextrack/?trknbr=<track number>
   title: FedEx Tracking
   tags:
   - fedex


### PR DESCRIPTION
This PR fixes two issues:
1. Fedex has updated the format for tracking URLs
2. The fedex shortcut was not using the <query> variable 

Examples with an invalid tracking number. This leads to a 404 error, but demonstrates the tracking number is being referenced
* Current version, goes to generic page, https://www.fedex.com/Tracking?tracknumbers=745671981192
* New version, goes to specific error message (i.e. looks up tracking number), https://www.fedex.com/fedextrack/?trknbr=745671981192
