### PR TITLE
Move JustWatch shortcut to Planet, Create US shortcut for search

### DIFF
--- a/data/shortcuts/.de.yml
+++ b/data/shortcuts/.de.yml
@@ -4799,15 +4799,6 @@ jf 1:
   examples:
   - arguments: He pulse tube cooler operating down to 1.3 K
     description: Sucht nach dem Artikel "He pulse tube cooler operating down to 1.3 K" in JustFind
-jw 0:
-  url: https://www.justwatch.com/
-  title: JustWatch
-  tags:
-  - movies
-  - series
-  examples:
-  - description: Gehe zur Startseite
-  description: Streaming-Suchmaschine für Filme und Serien
 jw 1:
   url: https://www.justwatch.com/de/Suche?q=<Suche>
   include: jw 0

--- a/data/shortcuts/.us.yml
+++ b/data/shortcuts/.us.yml
@@ -82,6 +82,13 @@ gps 1:
   examples:
   - arguments: iphone
     description: Search for "iphone"
+jw 1:
+  url: https://www.justwatch.com/us/search?q=<query>
+  title: JustWatch
+  tags:
+  - movies
+  - series
+  description: Streaming sources for films and movies
 sec 1:
   url: https://www.sec.gov/cgi-bin/browse-edgar?company=<company name>&CIK=&filenum=&State=&SIC=&owner=include&action=getcompany&type=
   title: EDGAR System of SEC for regulatory company information

--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -4918,8 +4918,6 @@ jw 0:
   - movies
   - series
   description: Streaming sources for films and movies
-jw 1:
-  url: 
 ka 0:
   include:
   - key: ka 0

--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -4911,6 +4911,15 @@ jsr 1:
   title: Java Specification Requests
   tags:
   - old
+jw 0:
+  url: https://www.justwatch.com/
+  title: JustWatch
+  tags:
+  - movies
+  - series
+  description: Streaming sources for films and movies
+jw 1:
+  url: 
 ka 0:
   include:
   - key: ka 0


### PR DESCRIPTION
The current shortcut for JustWatch, https://www.justwatch.com/, is only in the .de shortcuts. This site supports multiple languages. 

In this PR we move the base JustWatch shortcut to the planet shortcuts, o.yml. We also create a US based shortcut for searching JustWatch using the US interface.

Tested and verified working for jw and jw [query] for en/us. Did not test for .de version.