### PR TITLE
Fix links for Spotify, Zattoo. Remove broken US states

### DIFF
--- a/data/shortcuts/.us.yml
+++ b/data/shortcuts/.us.yml
@@ -123,9 +123,6 @@ sic 1:
   examples:
   - arguments: '1231'
     description: Search descriptive information for SIC "1231"
-state 1:
-  url: https://www.state.<query>.us
-  title: USA State Websites
 yp 2:
   url: https://www.yellowpages.com/search?search_terms=<business name>&geo_location_terms=<city or zip>
   title: Yellow Pages

--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -7486,7 +7486,7 @@ soup 1:
   tags:
   - old
 sp 1:
-  url: https://open.spotify.com/search/results/<query>
+  url: https://open.spotify.com/search/<query>
   title: Spotify
   tags:
   - music
@@ -9621,7 +9621,7 @@ zar 1:
       query: en.tr <1>
     created: '2023-04-10'
 zattoo 0:
-  url: https://watch.zattoo.com
+  url: https://zattoo.com/
   title: Zattoo
   tags:
   - old


### PR DESCRIPTION
Remove US state links which no longer exist

Fix links for Spotify and Zattoo default page

Tested on macOS