### PR TITLE
Open PWA URLs in External Browser

### DIFF
--- a/src/ts/modules/Helper.ts
+++ b/src/ts/modules/Helper.ts
@@ -30,7 +30,7 @@ export default class Helper {
    *
    * @param {string} url – The URL being navigated to.
    */
-  static openUrl(url) {
+  static openUrl(url: string) {
     if (this.isInStandaloneMode()) {
       window.open(url);
       return;

--- a/src/ts/modules/Helper.ts
+++ b/src/ts/modules/Helper.ts
@@ -24,4 +24,30 @@ export default class Helper {
     const text = await response.text();
     return text;
   }
+
+  /**
+   * Handles how URLs are opened.
+   *
+   * @param {string} url – The URL being navigated to.
+   */
+  static openUrl(url) {
+    if (this.isInStandaloneMode()) {
+      window.open(url);
+      return;
+    }
+
+    window.location.href = url;
+  }
+
+  /**
+   * Checks if application is inside PWA or not.
+   * Ref: https://stackoverflow.com/a/52695341/7596193
+   */
+  static isInStandaloneMode() {
+    return (
+      window.matchMedia("(display-mode: standalone)").matches ||
+      window.navigator.standalone ||
+      document.referrer.includes("android-app://")
+    );
+  }
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -382,8 +382,10 @@ export default class Home {
    * Checks if application is inside PWA or not.
    * https://stackoverflow.com/a/52695341/7596193
    */
-  const isInStandaloneMode = () =>
-        (window.matchMedia('(display-mode: standalone)').matches) || (window.navigator.standalone) || document.referrer.includes('android-app://');
+  isInStandaloneMode = () =>
+    window.matchMedia("(display-mode: standalone)").matches ||
+    window.navigator.standalone ||
+    document.referrer.includes("android-app://");
 
   /**
    * On triggering reload

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -364,8 +364,12 @@ export default class Home {
     this.openUrl(redirectUrl);
   };
 
-  /** TODO */
-  openUrl = (url) => {
+  /**
+   * Handles how URLs are opened.
+   *
+   * @param {string} url – The URL being navigated to.
+   */
+  openUrl = (url: string) => {
     if (this.isInStandaloneMode()) {
       window.open(url);
       return;
@@ -374,7 +378,9 @@ export default class Home {
     window.location.href = url;
   };
 
-  /** TODO */
+  /**
+   * Checks if application is inside PWA or not.
+   */
   const isInStandaloneMode = () =>
         (window.matchMedia('(display-mode: standalone)').matches) || (window.navigator.standalone) || document.referrer.includes('android-app://');
 

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -380,6 +380,7 @@ export default class Home {
 
   /**
    * Checks if application is inside PWA or not.
+   * https://stackoverflow.com/a/52695341/7596193
    */
   const isInStandaloneMode = () =>
         (window.matchMedia('(display-mode: standalone)').matches) || (window.navigator.standalone) || document.referrer.includes('android-app://');

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -5,6 +5,7 @@ import "../../scss/style.scss";
 import CallHandler from "./CallHandler";
 import Env from "./Env";
 import GitLogger from "./GitLogger";
+import Helper from "./Helper";
 import Settings from "./home/Settings";
 import Suggestions from "./home/Suggestions";
 import "@fortawesome/fontawesome-free/js/all.min";
@@ -348,7 +349,7 @@ export default class Home {
       const processUrl = this.env.buildProcessUrl({
         query: this.queryInput.value,
       });
-      this.openUrl(processUrl);
+      Helper.openUrl(processUrl);
       return;
     }
 
@@ -356,36 +357,13 @@ export default class Home {
 
     if (response.status === "found") {
       const redirectUrl = response.redirectUrl;
-      this.openUrl(redirectUrl);
+      Helper.openUrl(redirectUrl);
       return;
     }
 
     const redirectUrl = CallHandler.getRedirectUrlToHome(this.env, response);
-    this.openUrl(redirectUrl);
+    Helper.openUrl(redirectUrl);
   };
-
-  /**
-   * Handles how URLs are opened.
-   *
-   * @param {string} url – The URL being navigated to.
-   */
-  openUrl = (url: string) => {
-    if (this.isInStandaloneMode()) {
-      window.open(url);
-      return;
-    }
-
-    window.location.href = url;
-  };
-
-  /**
-   * Checks if application is inside PWA or not.
-   * https://stackoverflow.com/a/52695341/7596193
-   */
-  isInStandaloneMode = () =>
-    window.matchMedia("(display-mode: standalone)").matches ||
-    window.navigator.standalone ||
-    document.referrer.includes("android-app://");
 
   /**
    * On triggering reload

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -313,8 +313,8 @@ export default class Home {
         alertMsg.querySelector(".query").textContent = params.query;
         break;
       case "removed":
-        alertMsg.innerHTML = `The shortcut <a class="githubLink" target="_blank" href=""></a> was removed as does not adhere to our 
-          <a target="_blank" href="${this.env.data.config.url.docs}editors/policy/">Content policy</a>. 
+        alertMsg.innerHTML = `The shortcut <a class="githubLink" target="_blank" href=""></a> was removed as does not adhere to our
+          <a target="_blank" href="${this.env.data.config.url.docs}editors/policy/">Content policy</a>.
           But you can <a target="_blank" href="${this.env.data.config.url.docs}users/advanced/">
           create a user shortcut in your own namespace</a>.`;
         alertMsg.querySelector("a.githubLink").textContent = params.query;
@@ -343,25 +343,40 @@ export default class Home {
     envQuery.query = this.queryInput.value;
     await envQuery.populate();
 
-    const response = CallHandler.getRedirectResponse(envQuery);
-
     // Send debug to /process.
     if (envQuery.debug) {
       const processUrl = this.env.buildProcessUrl({
         query: this.queryInput.value,
       });
-      window.location.href = processUrl;
+      this.openUrl(processUrl);
       return;
     }
 
-    let redirectUrl;
+    const response = CallHandler.getRedirectResponse(envQuery);
+
     if (response.status === "found") {
-      redirectUrl = response.redirectUrl;
-    } else {
-      redirectUrl = CallHandler.getRedirectUrlToHome(this.env, response);
+      const redirectUrl = response.redirectUrl;
+      this.openUrl(redirectUrl);
+      return;
     }
-    window.location.href = redirectUrl;
+
+    const redirectUrl = CallHandler.getRedirectUrlToHome(this.env, response);
+    this.openUrl(redirectUrl);
   };
+
+  /** TODO */
+  openUrl = (url) => {
+    if (this.isInStandaloneMode()) {
+      window.open(url);
+      return;
+    }
+
+    window.location.href = url;
+  };
+
+  /** TODO */
+  const isInStandaloneMode = () =>
+        (window.matchMedia('(display-mode: standalone)').matches) || (window.navigator.standalone) || document.referrer.includes('android-app://');
 
   /**
    * On triggering reload

--- a/src/ts/modules/home/Suggestions.ts
+++ b/src/ts/modules/home/Suggestions.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 /** @module Suggestions */
+import Helper from "../Helper";
 import QueryParser from "../QueryParser";
 import SuggestionsGetter from "../SuggestionsGetter";
 import "@fortawesome/fontawesome-free/css/all.min.css";
@@ -319,7 +320,7 @@ export default class Suggestions {
     const urlLink = document.createElement("a");
     urlLink.href = "javascript:;";
     urlLink.onclick = () => {
-      this.home.openUrl(suggestion.url);
+      Helper.openUrl(suggestion.url);
     };
     urlLink.textContent = `${suggestion.url}`;
     urlDiv.appendChild(urlLink);

--- a/src/ts/modules/home/Suggestions.ts
+++ b/src/ts/modules/home/Suggestions.ts
@@ -317,7 +317,10 @@ export default class Suggestions {
     urlText.textContent = "🔗 ";
     urlDiv.appendChild(urlText);
     const urlLink = document.createElement("a");
-    urlLink.href = suggestion.url;
+    urlLink.href = "javascript:;";
+    urlLink.onclick = () => {
+      this.home.openUrl(suggestion.url);
+    };
     urlLink.textContent = `${suggestion.url}`;
     urlDiv.appendChild(urlLink);
     return urlDiv;


### PR DESCRIPTION
Resolves https://github.com/trovu/trovu/issues/329

## ✅ Solution

Instead of updating the `window.location.href`, this uses the `window.open` API to open the URL in another page.

## 🧪 Testing

After running:

```sh
npm run watch
```

And

```sh
npm run dev-server
```

I was able to visit the website and test all functionality on my laptop (e.g. command `g hello`).
- When visiting the webpage in the web browser, the commands open in the same window.
- When visiting the webpage in a PWA, the commands open in the external browser.

## 🤔 Open Questions

There are a couple of things I am not quite sure how to test on mobile devices specifically:
- I do not know how this will work on mobile devices. I imagine this will work just fine, but I would like someone else to verify this.
- Similar to the above, I am not sure if this will open in the "matching app".