### PR TITLE
Update Yahoo! Finance stock quote shortcut with new URL format

### DIFF
--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -10237,7 +10237,7 @@ ye 2:
   - arguments: pizza, new york
     description: Find pizza places in New York
 yf 1:
-  url: https://finance.yahoo.com/q?s=<abbreviation>
+  url: https://finance.yahoo.com/quote/<abbreviation>
   title: 'Yahoo Finance: Get stock quotes'
   tags:
   - old


### PR DESCRIPTION
Yahoo! changed the URL format to https://finance.yahoo.com/quote/MSFT