### PR TITLE
Ignore old-o namespaces.

### DIFF
--- a/src/ts/modules/NamespaceFetcher.ts
+++ b/src/ts/modules/NamespaceFetcher.ts
@@ -18,6 +18,11 @@ export default class NamespaceFetcher {
    * @returns {Object} An object containing namespace information
    */
   async getNamespaceInfos(namespaces) {
+    namespaces = namespaces.filter(
+      (namespace) =>
+        // Keep if it's not a string or doesn't start with "old-".
+        typeof namespace !== "string" || !namespace.startsWith("old-"),
+    );
     this.namespaceInfos = this.getInitialNamespaceInfos(namespaces, 1);
     this.namespaceInfos = await this.assignShortcutsFromData(this.namespaceInfos);
     this.namespaceInfos = this.addNamespaceInfos(this.namespaceInfos);


### PR DESCRIPTION
Some users still reference old-* namespace in their config, e.g.
```yaml
namespaces:
...
- old-de
- old-o
```
Trovu will then think they are user, fetching for shortcuts, e.g. in
```
https://raw.githubusercontent.com/old-o/trovu-data-user/master/shortcuts.yml
```
This leads to many requests, with Github eventually replying with [HTTP 429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429)

To prevent this, legacy configs with namespaces starting with `old-` shall be ignored.