### PR TITLE
Process page: respect dark color scheme.

### DIFF
--- a/src/html/process.html
+++ b/src/html/process.html
@@ -5,6 +5,18 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <!-- Set no referrer, to enable duckduckgo feeling lucky. -->
     <meta name="referrer" content="no-referrer" />
+    <style>
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #eee;
+          background: #121212;
+        }
+
+        body a {
+          color: #809fff;
+        }
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
This should get rid of unpleasant flashes of white encountered when using Trovu at night with dark mode on.