### PR TITLE
Fix external link handling in PWA service worker

### DIFF
--- a/src/js/pwa/service-worker.js
+++ b/src/js/pwa/service-worker.js
@@ -29,6 +29,22 @@ self.addEventListener("install", (event) => {
 
 // Implement fetch event to handle requests
 self.addEventListener("fetch", (event) => {
+  const requestUrl = new URL(event.request.url);
+  
+  // Handle external URLs (off-origin) - open in system browser
+  if (requestUrl.origin !== self.location.origin && event.request.mode === 'navigate') {
+    event.respondWith(
+      self.clients.openWindow(event.request.url).then(() => {
+        // Return a response to prevent the PWA from navigating
+        return new Response('', {
+          status: 204,
+          statusText: 'External link opened in system browser'
+        });
+      })
+    );
+    return;
+  }
+  
   event.respondWith(
     caches.match(event.request).then((response) => {
       // Cache hit - return response
@@ -40,17 +56,14 @@ self.addEventListener("fetch", (event) => {
         if (!response || response.status !== 200 || response.type !== "basic") {
           return response;
         }
-
         // IMPORTANT: Clone the response. A response is a stream
         // and because we want the browser to consume the response
         // as well as the cache consuming the response, we need
         // to clone it so we have two streams.
         var responseToCache = response.clone();
-
         caches.open(CACHE_NAME).then((cache) => {
           cache.put(event.request, responseToCache);
         });
-
         return response;
       });
     }),


### PR DESCRIPTION
## Description

Added logic to detect off-origin (external) URLs in the fetch event listener of the PWA service worker. When an external navigation is detected, the service worker now:

- Uses `clients.openWindow()` to open the URL in the system browser
- Prevents the PWA shell from navigating to external URLs
- Returns a 204 response to indicate successful handling

This ensures external links open in the system browser rather than being captured within the PWA interface, improving user experience and maintaining expected navigation behavior.

## Changes Made

- Modified the fetch event listener in `src/js/pwa/service-worker.js`
- Added URL origin detection logic
- Implemented external link handling with minimal code changes
- Used standard Web API methods (`clients.openWindow`)

## Testing

- External links should now open in the system browser
- Internal navigation within the PWA should remain unchanged
- No breaking changes to existing functionality

Fixes #329

## Description

Added logic to detect off-origin (external) URLs in the fetch event listener of the PWA service worker. When an external navigation is detected, the service worker now:

- Uses `clients.openWindow()` to open the URL in the system browser
- Prevents the PWA shell from navigating to external URLs
- Returns a 204 response to indicate successful handling

This ensures external links open in the system browser rather than being captured within the PWA interface, improving user experience and maintaining expected navigation behavior.

## Changes Made

- Modified the fetch event listener in `src/js/pwa/service-worker.js`
- Added URL origin detection logic
- Implemented external link handling with minimal code changes
- Used standard Web API methods (`clients.openWindow`)

## Testing

- External links should now open in the system browser
- Internal navigation within the PWA should remain unchanged
- No breaking changes to existing functionality

Fixes #329

/reward/reward…dling in PWA service workerFix external link handling in PWA service workerUpdate service-worker.js

Added logic to detect off-origin (external) URLs in the fetch event listener. When an external navigation is detected, the service worker now:
- Uses clients.openWindow() to open the URL in the system browser
- Prevents the PWA shell from navigating to external URLs
- Returns a 204 response to indicate successful handling

This ensures external links open in the system browser rather than being captured within the PWA interface, improving user experience.

Fixes #329

/reward