### PR TITLE
Add homepage and query for Claude AI

### DIFF
--- a/data/shortcuts/o.yml
+++ b/data/shortcuts/o.yml
@@ -1437,6 +1437,12 @@ cl 0:
 cl 1:
   url: https://www.colourlovers.com/colors/search?query=<color>
   include: cl 0
+claude 0:
+  url: https://claude.ai/
+  title: Query Claude AI
+claude 1:
+  url: https://claude.ai/new?q=<query>
+  title: Query Claude AI
 clpal 1:
   url: https://www.colourlovers.com/palettes/search?query=<query>
   title: COLOURlovers palette search


### PR DESCRIPTION
Add a shortcut to go to Claude AI, including generate a query for Claude. Note that it won't submit the query for security reasons, but it's ready to go.