### PR TITLE
fix: bind updateOpensearch in standalone PWA flow

### DIFF
--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -272,7 +272,7 @@ export default class Home {
   /**
    * Add and update Opensearch tag.
    */
-  updateOpensearch() {
+  updateOpensearch = () => {
     if (!this.env.language || !this.env.country) {
       return;
     }


### PR DESCRIPTION
Fixed the `this.updateOpensearch is not a function` error by binding `updateOpensearch` correctly.

Tested locally:
- no white screen
- no `updateOpensearch` console error
- app loads normally at `http://127.0.0.1:8081`
- external redirects like `g cats` work successfully

This is a clean PR based on the current `trovu/master`. @georgjaehnig 