### PR TITLE
fix: open target URLs in default browser when running as PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -44,7 +44,15 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (navigator as any).standalone;
+
+    if (isStandalone) {
+      window.open(redirectUrl, "_blank");
+    } else {
+      window.location.replace(redirectUrl);
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -253,7 +253,15 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (navigator as any).standalone;
+
+    if (isStandalone) {
+      window.open(redirectUrl, "_blank");
+    } else {
+      window.location.href = redirectUrl;
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes #329

When running as a PWA in standalone mode, target URLs now open in the default browser (or matching app) instead of navigating within the PWA window.

## Changes

- `CallHandler.ts` — redirect via `window.open` in standalone mode
- `Home.ts` — same for the search form redirect

Standalone mode is detected via `display-mode: standalone` media query (Android/desktop) and `navigator.standalone` (iOS Safari).

Internal navigation (hash changes, debug mode) is not affected.

## Tested

- All 75 unit tests pass
- TypeScript compiles without errors