### PR TITLE
fix: open target URLs in default browser when running as PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -42,7 +42,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    Env.navigateTo(redirectUrl);
   }
 
   /**

--- a/src/ts/modules/Env.test.ts
+++ b/src/ts/modules/Env.test.ts
@@ -99,3 +99,18 @@ describe("Env", () => {
     });
   });
 });
+
+describe("Env.isExternalUrl", () => {
+  test("detects external URL", () => {
+    expect(Env.isExternalUrl("https://www.google.com/search?q=foo")).toBe(true);
+  });
+  test("detects same-origin URL as internal", () => {
+    expect(Env.isExternalUrl("/index.html")).toBe(false);
+  });
+  test("detects relative URL as internal", () => {
+    expect(Env.isExternalUrl("../index.html#foo=bar")).toBe(false);
+  });
+  test("handles invalid URL gracefully", () => {
+    expect(Env.isExternalUrl("")).toBe(false);
+  });
+});

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -464,4 +464,39 @@ export default class Env {
   isRunningStandalone() {
     return window.navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
   }
+
+  /**
+   * Check if a URL is external (different origin from the current page).
+   *
+   * @param {string} url - The URL to check.
+   * @return {boolean} - True if the URL is external.
+   */
+  static isExternalUrl(url: string): boolean {
+    try {
+      const targetOrigin = new URL(url, window.location.origin).origin;
+      return targetOrigin !== window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Navigate to a URL. When running as a standalone PWA and the URL is
+   * external, open it in the device default browser (or matching app)
+   * instead of navigating inside the PWA window.
+   *
+   * @param {string} url - The URL to navigate to.
+   */
+  static navigateTo(url: string) {
+    const isStandalone =
+      (window as any).navigator.standalone ||
+      window.matchMedia("(display-mode: standalone)").matches;
+
+    if (isStandalone && Env.isExternalUrl(url)) {
+      window.open(url, "_blank");
+    } else {
+      window.location.replace(url);
+    }
+  }
+
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -254,7 +254,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    Env.navigateTo(redirectUrl);
   };
 
   /**


### PR DESCRIPTION
Fixes #329

## Problem

When Trovu is installed as a PWA (standalone mode), clicking a shortcut navigates the PWA window itself to the target URL via `window.location.replace()`. The user leaves Trovu and has to re-open the PWA to make another search. External URLs also cannot be routed to registered apps (YouTube, Google Maps, etc.) because the navigation stays inside the PWA context.

## Solution

Add `Env.navigateTo(url)` which detects whether the app is running in standalone mode and the target URL is external (different origin). In that case it uses `window.open(url, "_blank")` instead of `window.location.replace()`. This hands the URL to the operating system, which routes it to the default browser or a matching registered app.

Internal navigations (back to Trovu homepage, hash changes, debug mode) are unaffected.

## Changes

- **`Env.ts`**: Add `isExternalUrl()` static method to detect cross-origin URLs, and `navigateTo()` that picks the right navigation strategy based on display mode
- **`CallHandler.ts`**: Use `Env.navigateTo()` for the redirect at the end of `handleCall()`
- **`Home.ts`**: Use `Env.navigateTo()` for the redirect at the end of `submitQuery()`
- **`Env.test.ts`**: Add unit tests for `isExternalUrl()`

## Testing

- All 99 unit tests pass (95 existing + 4 new)
- All 26 call tests pass
- Build succeeds
- Lint passes

## Platform behavior

| Platform | Standalone PWA | Regular browser |
|----------|---------------|----------------|
| Desktop (Chrome/Edge) | Opens in new browser tab | No change (location.replace) |
| Android (Chrome) | Opens in Chrome Custom Tab or default browser | No change |
| iOS (Safari) | Opens in Safari | No change |

Note: On Android, `window.open` in a standalone PWA opens a Chrome Custom Tab (in-app browser overlay) which also surfaces the "Open in Chrome" option and respects app link handlers for registered apps like YouTube and Google Maps.