### PR TITLE
add tslib to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "ts-jest": "^29.3.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
-    "yaml-lint": "^1.7.0"
+    "yaml-lint": "^1.7.0",
+    "tslib": "^2.6.3"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.6.0",


### PR DESCRIPTION
Fixes tslib not installed error during build

@rollup/plugin-typescript requires tslib but it was not listed as a dependency, causing build failures for users.

Closes #592