### PR TITLE
fix: open external URLs in default browser when running as PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -41,7 +41,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    Env.navigateTo(redirectUrl, true);
   }
 
   /**

--- a/src/ts/modules/Env.test.ts
+++ b/src/ts/modules/Env.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment-options {"url": "https://trovu.net/process/index.html"}
+ */
 import Env from "./Env";
 
 const getUrlHashFooBar = () => {
@@ -96,6 +99,28 @@ describe("Env", () => {
     expect(Env.getBoolParams({ debug: "1", reload: "1", foo: "1" })).toEqual({
       debug: true,
       reload: true,
+    });
+  });
+
+  describe("isExternalUrl", () => {
+    test("returns true for different origin", () => {
+      expect(Env.isExternalUrl("https://google.com/search?q=foo")).toBe(true);
+    });
+
+    test("returns false for same origin absolute URL", () => {
+      expect(Env.isExternalUrl("https://trovu.net/index.html")).toBe(false);
+    });
+
+    test("returns false for relative URL", () => {
+      expect(Env.isExternalUrl("../index.html#foo=bar")).toBe(false);
+    });
+
+    test("returns false for root-relative URL", () => {
+      expect(Env.isExternalUrl("/index.html")).toBe(false);
+    });
+
+    test("returns false for invalid URL", () => {
+      expect(Env.isExternalUrl("not a url :::")).toBe(false);
     });
   });
 });

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -463,4 +463,57 @@ export default class Env {
   isRunningStandalone() {
     return window.navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
   }
+
+  /**
+   * Check whether a URL resolves to a different origin than the current page.
+   *
+   * @param {string} url - Absolute or relative URL to test.
+   * @returns {boolean}
+   */
+  static isExternalUrl(url: string): boolean {
+    if (typeof window === "undefined") return false;
+    try {
+      return new URL(url, window.location.href).origin !== window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Navigate to a URL, opening external URLs outside the PWA in standalone mode.
+   *
+   * window.open(url, '_blank') is typically blocked without a user gesture and,
+   * when it does work, always opens Chrome Custom Tab — bypassing Android's intent
+   * dispatch and ignoring the user's configured default browser.
+   *
+   * Dispatching a click on an <a> element goes through Android's intent resolution
+   * system, so the OS routes the URL to the user's actual default browser.
+   *
+   * @param {string}  url     - Target URL.
+   * @param {boolean} replace - Use history.replace instead of assign for internal nav.
+   */
+  static navigateTo(url: string, replace = false): void {
+    if (typeof window === "undefined") return;
+
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      Boolean((window.navigator as any).standalone);
+
+    if (isStandalone && Env.isExternalUrl(url)) {
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.target = "_blank";
+      anchor.rel = "noreferrer noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      return;
+    }
+
+    if (replace) {
+      window.location.replace(url);
+    } else {
+      window.location.href = url;
+    }
+  }
 }

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -482,12 +482,14 @@ export default class Env {
   /**
    * Navigate to a URL, opening external URLs outside the PWA in standalone mode.
    *
-   * window.open(url, '_blank') is typically blocked without a user gesture and,
-   * when it does work, always opens Chrome Custom Tab — bypassing Android's intent
-   * dispatch and ignoring the user's configured default browser.
+   * On Android, window.open() and target="_blank" are both intercepted by the
+   * PWA shell and remain inside Chrome, ignoring the user's default browser.
+   * The Android intent:// URI scheme bypasses this capture: Chrome hands the
+   * URI to Android's app-chooser / default-browser intent dispatcher, so the
+   * URL opens in whatever browser the user has set as default.
    *
-   * Dispatching a click on an <a> element goes through Android's intent resolution
-   * system, so the OS routes the URL to the user's actual default browser.
+   * On iOS standalone mode, window.open(url, '_blank') correctly spawns a new
+   * Safari window outside the PWA.
    *
    * @param {string}  url     - Target URL.
    * @param {boolean} replace - Use history.replace instead of assign for internal nav.
@@ -495,18 +497,28 @@ export default class Env {
   static navigateTo(url: string, replace = false): void {
     if (typeof window === "undefined") return;
 
-    const isStandalone =
-      window.matchMedia("(display-mode: standalone)").matches ||
-      Boolean((window.navigator as any).standalone);
+    const isStandaloneAndroid =
+      window.matchMedia("(display-mode: standalone)").matches &&
+      /android/i.test(navigator.userAgent);
 
-    if (isStandalone && Env.isExternalUrl(url)) {
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.target = "_blank";
-      anchor.rel = "noreferrer noopener";
-      document.body.appendChild(anchor);
-      anchor.click();
-      document.body.removeChild(anchor);
+    const isStandaloneIos = Boolean((window.navigator as any).standalone);
+
+    if ((isStandaloneAndroid || isStandaloneIos) && Env.isExternalUrl(url)) {
+      if (isStandaloneAndroid) {
+        // Build an Android intent URI so the OS dispatches to the default browser.
+        const parsed = new URL(url);
+        const scheme = parsed.protocol.replace(":", "");
+        const rest = `${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`;
+        const intentUrl = `intent://${rest}#Intent;scheme=${scheme};action=android.intent.action.VIEW;end`;
+        const a = document.createElement("a");
+        a.href = intentUrl;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      } else {
+        // iOS: window.open creates a new Safari window outside the PWA.
+        window.open(url, "_blank", "noopener");
+      }
       return;
     }
 

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -482,14 +482,17 @@ export default class Env {
   /**
    * Navigate to a URL, opening external URLs outside the PWA in standalone mode.
    *
-   * On Android, window.open() and target="_blank" are both intercepted by the
-   * PWA shell and remain inside Chrome, ignoring the user's default browser.
-   * The Android intent:// URI scheme bypasses this capture: Chrome hands the
+   * On Chrome Android, window.open() and target="_blank" are both intercepted
+   * by the PWA shell and remain inside Chrome, ignoring the user's default
+   * browser. The Android intent:// URI scheme bypasses this: Chrome hands the
    * URI to Android's app-chooser / default-browser intent dispatcher, so the
    * URL opens in whatever browser the user has set as default.
    *
-   * On iOS standalone mode, window.open(url, '_blank') correctly spawns a new
-   * Safari window outside the PWA.
+   * Brave Android does not route intent:// to the OS intent dispatcher the
+   * same way — its PWA shell intercepts the navigation before the OS sees it.
+   * For Brave (detected synchronously via `'brave' in navigator`) and for iOS
+   * standalone mode, window.open(url, '_blank') correctly spawns a new browser
+   * window outside the PWA.
    *
    * @param {string}  url     - Target URL.
    * @param {boolean} replace - Use history.replace instead of assign for internal nav.
@@ -503,9 +506,13 @@ export default class Env {
 
     const isStandaloneIos = Boolean((window.navigator as any).standalone);
 
+    // Brave exposes navigator.brave synchronously; its PWA shell does not pass
+    // intent:// URIs to the Android OS intent dispatcher the way Chrome does.
+    const isBrave = "brave" in navigator;
+
     if ((isStandaloneAndroid || isStandaloneIos) && Env.isExternalUrl(url)) {
-      if (isStandaloneAndroid) {
-        // Build an Android intent URI so the OS dispatches to the default browser.
+      if (isStandaloneAndroid && !isBrave) {
+        // Chrome Android: build an intent URI so the OS dispatches to the default browser.
         const parsed = new URL(url);
         const scheme = parsed.protocol.replace(":", "");
         const rest = `${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`;
@@ -516,7 +523,7 @@ export default class Env {
         a.click();
         document.body.removeChild(a);
       } else {
-        // iOS: window.open creates a new Safari window outside the PWA.
+        // iOS, or Brave Android: window.open spawns a new browser window outside the PWA.
         window.open(url, "_blank", "noopener");
       }
       return;

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -482,17 +482,14 @@ export default class Env {
   /**
    * Navigate to a URL, opening external URLs outside the PWA in standalone mode.
    *
-   * On Chrome Android, window.open() and target="_blank" are both intercepted
-   * by the PWA shell and remain inside Chrome, ignoring the user's default
-   * browser. The Android intent:// URI scheme bypasses this: Chrome hands the
-   * URI to Android's app-chooser / default-browser intent dispatcher, so the
-   * URL opens in whatever browser the user has set as default.
+   * On Android, window.open() and target="_blank" are both intercepted by the
+   * PWA shell and remain inside the browser, ignoring the user's default
+   * browser. The Android intent:// URI scheme bypasses this: it hands the URI
+   * to Android's app-chooser / default-browser intent dispatcher, so the URL
+   * opens in whatever browser the user has set as default.
    *
-   * Brave Android does not route intent:// to the OS intent dispatcher the
-   * same way — its PWA shell intercepts the navigation before the OS sees it.
-   * For Brave (detected synchronously via `'brave' in navigator`) and for iOS
-   * standalone mode, window.open(url, '_blank') correctly spawns a new browser
-   * window outside the PWA.
+   * On iOS standalone mode, window.open(url, '_blank') correctly spawns a new
+   * browser window outside the PWA.
    *
    * @param {string}  url     - Target URL.
    * @param {boolean} replace - Use history.replace instead of assign for internal nav.
@@ -506,13 +503,9 @@ export default class Env {
 
     const isStandaloneIos = Boolean((window.navigator as any).standalone);
 
-    // Brave exposes navigator.brave synchronously; its PWA shell does not pass
-    // intent:// URIs to the Android OS intent dispatcher the way Chrome does.
-    const isBrave = "brave" in navigator;
-
     if ((isStandaloneAndroid || isStandaloneIos) && Env.isExternalUrl(url)) {
-      if (isStandaloneAndroid && !isBrave) {
-        // Chrome Android: build an intent URI so the OS dispatches to the default browser.
+      if (isStandaloneAndroid) {
+        // Android standalone: build an intent URI so the OS dispatches to the default browser.
         const parsed = new URL(url);
         const scheme = parsed.protocol.replace(":", "");
         const rest = `${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`;
@@ -523,7 +516,7 @@ export default class Env {
         a.click();
         document.body.removeChild(a);
       } else {
-        // iOS, or Brave Android: window.open spawns a new browser window outside the PWA.
+        // iOS standalone: window.open spawns a new browser window outside the PWA.
         window.open(url, "_blank", "noopener");
       }
       return;

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -254,7 +254,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    Env.navigateTo(redirectUrl);
   };
 
   /**


### PR DESCRIPTION
Fixes #329

## Why all previous PRs failed

Every prior attempt used `window.open(url, '_blank')` or `<a target="_blank">` clicks.

The maintainer confirmed on Android 14: **`target="_blank"` makes no difference** — Chrome's PWA shell intercepts the navigation and keeps it inside the app, regardless of the user's configured default browser.

`window.open()` has the same problem: even when not popup-blocked, it opens a Chrome Custom Tab (Chrome's own renderer), completely bypassing Android's intent system.

## Why the intent:// URI scheme works

`intent://` is not an HTTP/HTTPS URL. Chrome does not treat it as web navigation — it passes it to **Android's intent dispatcher**, which routes it through the OS app-chooser. The URL opens in whichever browser the user has set as default (Firefox, Brave, Samsung Internet, etc.), exactly as if they had tapped a link in a native app.

This is the mechanism that deep-links use. It explicitly bypasses Chrome's PWA link capture.

## Platform handling

| Context | Behaviour |
|---|---|
| Android PWA (`display-mode: standalone`) | Build `intent://` URI → click via anchor → OS dispatches to default browser |
| iOS PWA (`navigator.standalone`) | `window.open(url, '_blank', 'noopener')` → new Safari window (works correctly on iOS) |
| Desktop PWA or non-PWA | `window.location.replace` / `window.location.href` (unchanged) |

## Changes

- **`Env.ts`** — `isExternalUrl(url)` + `navigateTo(url, replace?)` with platform-aware external URL handling
- **`CallHandler.ts`** — `window.location.replace(redirectUrl)` → `Env.navigateTo(redirectUrl, true)`
- **`Home.ts`** — `window.location.href = redirectUrl` → `Env.navigateTo(redirectUrl)`
- **`Env.test.ts`** — 5 unit tests for `isExternalUrl`