### PR TITLE
Open external shortcut targets outside standalone PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -7,6 +7,27 @@ import UrlProcessor from "./UrlProcessor";
 /** Handle a call. */
 
 export default class CallHandler {
+  static isExternalUrl(url: string) {
+    try {
+      return new URL(url, window.location.href).origin !== window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  static isRunningStandalone() {
+    return window.navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
+  }
+
+  static openRedirectUrl(url: string) {
+    if (this.isRunningStandalone() && this.isExternalUrl(url)) {
+      window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    window.location.replace(url);
+  }
+
   /**
    * The 'main' function of this class.
    */
@@ -41,7 +62,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.openRedirectUrl(redirectUrl);
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -254,7 +254,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.openRedirectUrl(redirectUrl);
   };
 
   /**


### PR DESCRIPTION
Fixes #329.

When Trovu is installed as a standalone PWA, shortcut redirects that resolve to an external origin should open in the default browser instead of replacing the PWA window.

This change:
- adds a shared redirect helper that detects standalone display mode and external origins
- uses `window.open(..., "_blank", "noopener,noreferrer")` for external targets in standalone mode
- keeps the existing `window.location.replace` behavior for non-standalone use and same-origin/home redirects
- routes the home-page submit path through the same helper so both entry points behave consistently

I could not run the repo test suite in this environment because `npm` is not installed here, but I manually checked the URL/origin and standalone-mode branch logic.