### PR TITLE
Open target URLs externally from PWA

### DIFF
--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -248,14 +248,35 @@ export default class Home {
       return;
     }
 
-    let redirectUrl: string;
     if (response.status === "found") {
-      redirectUrl = response.redirectUrl;
-    } else {
-      redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
+      this.openRedirectUrl(response.redirectUrl, true);
+      return;
     }
-    window.location.href = redirectUrl;
+
+    this.openRedirectUrl(CallHandler.getRedirectUrlToHome(envQuery, response));
   };
+
+  /**
+   * Open redirect URLs.
+   *
+   * When Trovu runs as an installed PWA, replacing the current location keeps
+   * external target URLs inside the PWA shell. Opening found target URLs in a
+   * new browsing context lets the browser/OS route them to the default browser
+   * or a matching native app instead.
+   *
+   * Non-result redirects keep the existing in-app navigation behavior.
+   *
+   * @param {string} redirectUrl - The target URL.
+   * @param {boolean} external - Whether to open externally in standalone mode.
+   */
+  openRedirectUrl(redirectUrl: string, external = false) {
+    if (external && this.env.isRunningStandalone()) {
+      window.open(redirectUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    window.location.href = redirectUrl;
+  }
 
   /**
    * On triggering reload


### PR DESCRIPTION
## Summary

Fixes #329 by opening resolved target URLs in a new browsing context when Trovu is running as an installed PWA.

When the app is in standalone display mode, assigning a found target URL to `window.location.href` keeps the external target inside the PWA shell. Using `window.open(..., "_blank", "noopener,noreferrer")` for found target URLs lets the browser/OS route the URL to the default browser or a matching native app instead.

Non-result redirects, such as returning to Trovu's home page, keep the existing in-app navigation behavior.

## Verification

- `npm run lint-js`
- `npm run build`
