### PR TITLE
Open PWA target URLs in a new browsing context

### DIFF
--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -251,6 +251,12 @@ export default class Home {
     let redirectUrl: string;
     if (response.status === "found") {
       redirectUrl = response.redirectUrl;
+      if (this.env.isRunningStandalone()) {
+        const openedWindow = window.open(redirectUrl, "_blank", "noopener,noreferrer");
+        if (openedWindow) {
+          return;
+        }
+      }
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }


### PR DESCRIPTION
Fixes #329.

When Trovu is running as an installed standalone PWA and a query resolves to a target URL, open the final target with `window.open(..., "_blank", "noopener,noreferrer")` instead of navigating the PWA window directly.

This lets the browser route the target URL outside the installed PWA shell, so external URLs can open in the default browser or matching installed app. If opening a new context is blocked, the code falls back to the existing navigation behavior.

Validation:

- `git diff --check`

Note: I could not run the full npm test suite in this environment because `npm` is not available on PATH.

Opire claim note:

/claim #329