### PR TITLE
Open shortcut targets outside standalone PWA

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -26,4 +26,35 @@ describe("CallHandler", () => {
       "../index.html#country=at&language=de&status=reloaded",
     );
   });
+  describe("standalone external navigation", () => {
+    const standaloneEnv = {
+      isRunningStandalone: jest.fn(() => true),
+    };
+    const browserEnv = {
+      isRunningStandalone: jest.fn(() => false),
+    };
+
+    test("opens external HTTP URLs outside standalone PWA", () => {
+      expect(CallHandler.shouldOpenExternally("https://www.google.com/search?q=test", standaloneEnv)).toBe(true);
+    });
+
+    test("keeps same-origin URLs inside standalone PWA", () => {
+      expect(CallHandler.shouldOpenExternally("../index.html#language=en", standaloneEnv)).toBe(false);
+      expect(CallHandler.shouldOpenExternally(`${window.location.origin}/process/index.html`, standaloneEnv)).toBe(
+        false,
+      );
+    });
+
+    test("keeps all URLs inside normal browser tabs", () => {
+      expect(CallHandler.shouldOpenExternally("https://www.google.com/search?q=test", browserEnv)).toBe(false);
+    });
+
+    test("uses window.open for external standalone redirects", () => {
+      window.open = jest.fn();
+
+      CallHandler.openUrl("https://www.google.com/search?q=test", standaloneEnv);
+
+      expect(window.open).toHaveBeenCalledWith("https://www.google.com/search?q=test", "_blank", "noopener,noreferrer");
+    });
+  });
 });

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -41,7 +41,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.openUrl(redirectUrl, env, true);
   }
 
   /**
@@ -132,5 +132,35 @@ export default class CallHandler {
     const paramStr = env.buildUrlParamStr(params);
     const redirectUrl = "../index.html#" + paramStr;
     return redirectUrl;
+  }
+
+  static shouldOpenExternally(url: string, env: AnyObject) {
+    if (!url || !env.isRunningStandalone || !env.isRunningStandalone()) {
+      return false;
+    }
+
+    try {
+      const targetUrl = new URL(url, window.location.href);
+      if (targetUrl.protocol === "http:" || targetUrl.protocol === "https:") {
+        return targetUrl.origin !== window.location.origin;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  static openUrl(url: string, env: AnyObject, replace = false) {
+    if (this.shouldOpenExternally(url, env)) {
+      window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    if (replace) {
+      window.location.replace(url);
+      return;
+    }
+
+    window.location.href = url;
   }
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -254,7 +254,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.openUrl(redirectUrl, this.env);
   };
 
   /**


### PR DESCRIPTION
## Summary

- open resolved shortcut target URLs in a new external browser context when Trovu runs as a standalone PWA
- keep same-origin Trovu navigation inside the PWA
- reuse the same navigation helper from both direct homepage submissions and the process redirect page

Fixes #329.

## Validation

- `npx jest --verbose src/ts/modules/CallHandler.test.ts`
- `npm run build`

/claim #329