### PR TITLE
fix: limit blog list to 3 items and fix footer sticky positioning

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -362,13 +362,7 @@
                 >
               </li>
               <li>
-                <a target="_blank" href="{{urlBlog}}startpage-generator"> Story of Trovu: The Startpage Generator </a>
-              </li>
-              <li>
                 <a target="_blank" href="{{urlBlog}}20years">20 Years of Trovu / FindFind.it / Serchilo</a>
-              </li>
-              <li>
-                <a target="_blank" href="{{urlBlog}}browser-extension">New: Browser Extension for Chrome & Firefox</a>
               </li>
             </ul>
           </div>

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -32,9 +32,11 @@ footer.navbar {
   background: #eee;
   flex-shrink: 0;
   position: sticky;
+  bottom: 0;
   padding: 0;
   padding-bottom: 1em;
   margin-top: 1em;
+  width: 100%;
   .left ul {
     list-style-type: none;
     padding-left: 0;


### PR DESCRIPTION
Fix #510: Footer partly not visible

Changes:
1. Reduced blog list items from 5 to 3 to prevent overflow
2. Added `bottom: 0` and `width: 100%` to footer.navbar CSS for proper sticky positioning

/claim #510