### PR TITLE
fix: Open target URLs outside PWA via simulated anchor click

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,30 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.openUrl(redirectUrl, true);
+  }
+
+  /**
+   * Helper to open URLs, breaking out of standalone PWA if needed.
+   */
+  static openUrl(url: string, replace: boolean = false) {
+    const isStandalone = 
+      window.matchMedia("(display-mode: standalone)").matches || 
+      (window.navigator as any).standalone === true;
+
+    if (isStandalone) {
+      const a = document.createElement("a");
+      a.href = url;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } else if (replace) {
+      window.location.replace(url);
+    } else {
+      window.location.href = url;
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -307,17 +307,17 @@ export default class Home {
       const processUrl = this.env.buildProcessUrl({
         query: this.queryInput.value,
       });
-      window.location.href = processUrl;
+      CallHandler.openUrl(processUrl);
       return;
     }
 
-    let redirectUrl: string;
+    let redirectUrl;
     if (response.status === "found") {
-      redirectUrl = response.redirectUrl as string;
+      redirectUrl = response.redirectUrl;
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.openUrl(redirectUrl);
   };
 
   /**


### PR DESCRIPTION
Fixes #329

This PR solves the Android standalone PWA external link routing issue by using a simulated `<a>` click rather than `window.open()` or `window.location.replace()`.

**Why standard `window.open` fails on Android:**
When the PWA calculates the redirection URL, it executes asynchronous tasks (e.g., `await envQuery.populate(params)`). This asynchronous execution breaks the "User Gesture" context required by Chrome to allow popup/new tab openings. As a result, standard `window.open` either fails or is trapped within the PWA scope.

**How this PR fixes it:**
1. Added `CallHandler.openUrl()` helper to consistently detect `isStandalonePWA`.
2. When in standalone mode, it creates a temporary `<a>` element with `target="_blank"` and `rel="noopener noreferrer"` and clicks it. This effectively tells the OS to break out of the PWA scope and open the user's default browser or intended app.
3. If not in standalone mode, it defaults to standard `location.replace`/`href` behavior.

/claim #329
