### PR TITLE
Fix stale not_found query after invalid submit

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -27,6 +27,17 @@ describe("CallHandler", () => {
       "../index.html#country=at&language=de&status=reloaded",
     );
   });
+  test("getRedirectUrlToHome keeps the populated query over the stale URL query", async () => {
+    Env.getUrlHash = () => {
+      return "country=gb&language=de&query=google&status=not_found";
+    };
+    const response = {
+      status: "not_found",
+    };
+    expect(CallHandler.getRedirectUrlToHome(new Env({ query: "wikipedia" }), response)).toStrictEqual(
+      "../index.html#country=gb&language=de&query=wikipedia&status=not_found",
+    );
+  });
   test("isSafeRedirectUrl allows http, https and mailto", () => {
     expect(CallHandler.isSafeRedirectUrl("http://example.com")).toBe(true);
     expect(CallHandler.isSafeRedirectUrl("https://example.com")).toBe(true);

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -141,9 +141,7 @@ export default class CallHandler {
    */
   static getRedirectUrlToHome(env: Pick<Env, "buildUrlParamStr">, response: RedirectResponse): string {
     const params = Env.getParamsFromUrl();
-    if (params.query === "reload" || params.query === "debug:reload") {
-      delete params.query;
-    }
+    delete params.query;
     for (const property of ["alternative", "key", "namespace", "status"]) {
       if (response[property]) {
         params[property] = response[property];

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -112,6 +112,15 @@ test.describe("Homepage status states", () => {
     await expect(page.locator("#target-domain")).toContainText("https://www.google");
   });
 
+  test("should update the not_found query after another invalid submit", async ({ page }) => {
+    await openLoadedHomepage(page, "#country=gb&language=de&query=google&status=not_found");
+    await page.locator("#query").fill("wikipedia");
+    await page.locator("#query").press("Enter");
+    await expect(page).toHaveURL(/query=wikipedia/);
+    await expect(page.locator("#query")).toHaveValue("wikipedia");
+    await expect(page.getByText("No matching shortcut found.")).toBeVisible();
+  });
+
   test("should prefill the alternative query for deprecated shortcuts", async ({ page }) => {
     await openLoadedHomepage(page, "#country=gb&language=en&query=oldshortcut&status=deprecated&alternative=g%20berlin");
     await expect(page.locator("#query")).toHaveValue("g berlin");


### PR DESCRIPTION
## Summary
- prevent a stale URL hash query from overriding the freshly submitted query when redirecting back to the homepage for status states
- add a unit regression for `getRedirectUrlToHome`
- add Playwright coverage for resubmitting an invalid query from a `not_found` page

Fixes #524.

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx jest --verbose src/ts/modules/CallHandler.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run lint-js`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run build`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx playwright test tests/playwright/home.spec.js -g "should update the not_found query"`