### PR TITLE
fix: open external URLs in default browser when running as PWA (#329)   

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,25 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    const isStandalone = window.matchMedia(
+      "(display-mode: standalone)",
+    ).matches;
+    if (isStandalone) {
+      const a = document.createElement("a");
+      a.setAttribute("href", redirectUrl);
+      a.setAttribute("target", "_blank");
+      a.setAttribute("rel", "noopener noreferrer");
+      a.style.display = "none";
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(() => {
+        if (a.parentNode) {
+          a.parentNode.removeChild(a);
+        }
+      }, 100);
+    } else {
+      window.location.replace(redirectUrl);
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -292,6 +292,19 @@ export default class Home {
       event.preventDefault();
     }
 
+    // Open a blank window during the user gesture so we can
+    // redirect it to the external target URL after async processing.
+    // This is necessary for PWAs, where navigation after losing the
+    // user gesture stays inside the PWA instead of opening the
+    // default browser.
+    const isStandalone = window.matchMedia(
+      "(display-mode: standalone)",
+    ).matches;
+    let externalWindow: Window | null = null;
+    if (isStandalone) {
+      externalWindow = window.open("about:blank", "_blank");
+    }
+
     // Must create new env instance here,
     // because extraNamespace might have changed reachability,
     // or asking for a not yet parsed Github namespace.
@@ -308,6 +321,9 @@ export default class Home {
         query: this.queryInput.value,
       });
       window.location.href = processUrl;
+      if (externalWindow && !externalWindow.closed) {
+        externalWindow.close();
+      }
       return;
     }
 
@@ -317,7 +333,17 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    // If we have an external window open, redirect it to the target.
+    // Otherwise, fall back to in-PWA navigation.
+    if (externalWindow && !externalWindow.closed) {
+      try {
+        externalWindow.location.href = redirectUrl;
+      } catch {
+        window.location.href = redirectUrl;
+      }
+    } else {
+      window.location.href = redirectUrl;
+    }
   };
 
   /**


### PR DESCRIPTION
## What this does
  
  This fixes #329 by opening a blank window during the submit gesture (BEFORE
  the `await`), then redirecting it to the external URL after async processing.

  ## Why previous PRs failed
  
  All previous attempts opened windows or clicked anchors AFTER the async
  processing, when the user gesture context was already lost. On Android PWAs,
  navigation without a user gesture stays inside the PWA scope, regardless of
  `target="_blank"` or anchor tricks.

  ## What's different here
  
  The key change is in `Home.submitQuery()`: `window.open("about:blank",
  "_blank")` is called immediately after `event.preventDefault()`, while the
  submit event's user gesture is still active. The blank window is then
  redirected to the target URL after `await envQuery.populate()` completes.

  For the process page path (`CallHandler.handleCall()`), an anchor element with
   `target="_blank"` is used since the process page runs on load without a user
  gesture.

  ## Files changed

  - `src/ts/modules/Home.ts` - Pre-open external window during submit gesture
  - `src/ts/modules/CallHandler.ts` - Anchor-click approach for process page
  
  ---
  
  I am a human who is writing this comment, not an AI.