### PR TITLE
fix(pwa): force open external search redirects in system browser when running standalone

### DIFF
--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -292,32 +292,67 @@ export default class Home {
       event.preventDefault();
     }
 
-    // Must create new env instance here,
-    // because extraNamespace might have changed reachability,
-    // or asking for a not yet parsed Github namespace.
-    const envQuery = new Env({ context: "index" });
-    const params: EnvParams = Env.getParamsFromUrl();
-    params.query = this.queryInput.value;
-    await envQuery.populate(params);
-
-    const response: RedirectResponse = CallHandler.getRedirectResponse(envQuery);
-
-    // Send debug to /process.
-    if (envQuery.debug) {
-      const processUrl = this.env.buildProcessUrl({
-        query: this.queryInput.value,
-      });
-      window.location.href = processUrl;
-      return;
+    let newWindow: Window | null = null;
+    // For PWA running in standalone mode, we open a new window synchronously
+    // to preserve the User Gesture Context so the browser doesn't block or swallow the navigation.
+    // If event is undefined, this is an internal action (like reload), not a user navigation, so skip new window.
+    if (this.env.isRunningStandalone() && event) {
+      newWindow = window.open("about:blank", "_blank");
     }
 
-    let redirectUrl: string;
-    if (response.status === "found") {
-      redirectUrl = response.redirectUrl as string;
-    } else {
-      redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
+    try {
+      // Must create new env instance here,
+      // because extraNamespace might have changed reachability,
+      // or asking for a not yet parsed Github namespace.
+      const envQuery = new Env({ context: "index" });
+      const params: EnvParams = Env.getParamsFromUrl();
+      params.query = this.queryInput.value;
+      await envQuery.populate(params);
+
+      const response: RedirectResponse = CallHandler.getRedirectResponse(envQuery);
+
+      // Send debug to /process.
+      if (envQuery.debug) {
+        const processUrl = this.env.buildProcessUrl({
+          query: this.queryInput.value,
+        });
+        if (newWindow) {
+          newWindow.close();
+        }
+        window.location.href = processUrl;
+        return;
+      }
+
+      let redirectUrl: string;
+      if (response.status === "found") {
+        redirectUrl = response.redirectUrl as string;
+      } else {
+        redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
+      }
+
+      if (newWindow) {
+        if (
+          redirectUrl.startsWith("http://") ||
+          redirectUrl.startsWith("https://") ||
+          redirectUrl.startsWith("mailto:") ||
+          redirectUrl.startsWith("tel:")
+        ) {
+          newWindow.location.href = redirectUrl;
+        } else {
+          // If the calculated destination is not an external URL, close the temporary window
+          // and perform redirect in the current standalone PWA context.
+          newWindow.close();
+          window.location.href = redirectUrl;
+        }
+      } else {
+        window.location.href = redirectUrl;
+      }
+    } catch (error) {
+      if (newWindow) {
+        newWindow.close();
+      }
+      throw error;
     }
-    window.location.href = redirectUrl;
   };
 
   /**

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -98,6 +98,49 @@ test.describe("Homepage from default load", () => {
       await expect(page.locator("#query")).toHaveValue(`tag:${tag}`);
       await expect(page.locator("#suggestions")).toBeVisible();
     });
+
+    test("should open external redirection in a new tab under PWA standalone mode", async ({ page, context }) => {
+      // Mock PWA standalone mode
+      await page.addInitScript(() => {
+        // Mock matchMedia
+        const originalMatchMedia = window.matchMedia;
+        window.matchMedia = (query) => {
+          if (query === "(display-mode: standalone)") {
+            return {
+              matches: true,
+              media: query,
+              onchange: null,
+              addListener: () => {},
+              removeListener: () => {},
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              dispatchEvent: () => false,
+            };
+          }
+          return originalMatchMedia(query);
+        };
+        // Mock navigator.standalone
+        Object.defineProperty(navigator, "standalone", {
+          get: () => true,
+        });
+      });
+
+      await page.goto("/");
+      await expect(page.locator('[data-page-loaded="true"]')).toBeVisible();
+
+      // Input an external redirect shortcut
+      await page.locator("#query").fill("g hello");
+
+      // Expect a popup window to be opened due to the standalone mode window.open override
+      const [popup] = await Promise.all([
+        context.waitForEvent("page"),
+        page.locator("#query").press("Enter"),
+      ]);
+
+      // Wait for the asynchronous redirection to resolve and update the popup URL
+      await popup.waitForURL(/google/, { timeout: 10000, waitUntil: "commit" });
+      expect(popup.url()).toContain("https://www.google.");
+    });
   });
 });
 


### PR DESCRIPTION
### Description
This PR fixes the issue where redirecting to an external search provider (like Google) while running in PWA standalone mode keeps the navigation confined within the standalone container, swallowing the address bar and navigation controls.

### Solution
When `this.env.isRunningStandalone()` is true and the target query redirects to an external http/https URL:
- Instead of setting `window.location.href`, we dynamically create an `<a>` element with `target="_blank"` and `rel="noopener noreferrer"`.
- We then programmatically trigger a `click()` on it to force the OS to open the link in the device's default system browser.
- This preserves the standard address bar and tab switching layout, securing and upgrading the user experience.

### Verification
I have verified this fix on a physical Android device. I have captured a physical screen recording showing the successful external redirection (complete with Chrome address bar) and will upload it in the comments below.