### PR TITLE
Fix PWA external target navigation

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -3,6 +3,7 @@ import Env from "./Env";
 import GitLogger from "./GitLogger";
 import ShortcutFinder from "./ShortcutFinder";
 import UrlProcessor from "./UrlProcessor";
+import { getExternalNavigationUrl } from "./ExternalNavigator";
 import type { EnvLike, RedirectResponse, Shortcut } from "../types";
 
 /** Handle a call. */
@@ -45,7 +46,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    window.location.replace(response.status === "found" ? getExternalNavigationUrl(redirectUrl) : redirectUrl);
   }
 
   /**

--- a/src/ts/modules/ExternalNavigator.test.ts
+++ b/src/ts/modules/ExternalNavigator.test.ts
@@ -1,0 +1,93 @@
+import { getAndroidIntentUrl, getExternalNavigationUrl, navigateExternalUrl } from "./ExternalNavigator";
+
+describe("ExternalNavigator", () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalUserAgent = window.navigator.userAgent;
+  const originalStandalone = window.navigator.standalone;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: originalUserAgent,
+    });
+    Object.defineProperty(window.navigator, "standalone", {
+      configurable: true,
+      value: originalStandalone,
+    });
+  });
+
+  function setDisplayModeStandalone(standalone: boolean) {
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: query === "(display-mode: standalone)" ? standalone : false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+  }
+
+  function setNavigator(userAgent: string, standalone = false) {
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: userAgent,
+    });
+    Object.defineProperty(window.navigator, "standalone", {
+      configurable: true,
+      value: standalone,
+    });
+  }
+
+  test("getAndroidIntentUrl converts http and https URLs", () => {
+    expect(getAndroidIntentUrl("https://example.com/search?q=trovu")).toBe(
+      "intent://example.com/search?q=trovu#Intent;scheme=https;S.browser_fallback_url=https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dtrovu;end",
+    );
+    expect(getAndroidIntentUrl("http://example.com/path")).toBe(
+      "intent://example.com/path#Intent;scheme=http;S.browser_fallback_url=http%3A%2F%2Fexample.com%2Fpath;end",
+    );
+  });
+
+  test("getAndroidIntentUrl rejects non-web and invalid URLs", () => {
+    expect(getAndroidIntentUrl("mailto:test@example.com")).toBe(false);
+    expect(getAndroidIntentUrl("not a url")).toBe(false);
+  });
+
+  test("getExternalNavigationUrl uses Android intent URLs only inside Android PWAs", () => {
+    setDisplayModeStandalone(true);
+    setNavigator("Mozilla/5.0 (Linux; Android 15)");
+
+    expect(getExternalNavigationUrl("https://example.com/search?q=trovu")).toMatch(
+      /^intent:\/\/example\.com\/search\?q=trovu#Intent;scheme=https;/,
+    );
+  });
+
+  test("getExternalNavigationUrl keeps normal browser and non-Android navigation unchanged", () => {
+    setDisplayModeStandalone(false);
+    setNavigator("Mozilla/5.0 (Linux; Android 15)");
+    expect(getExternalNavigationUrl("https://example.com")).toBe("https://example.com");
+
+    setDisplayModeStandalone(true);
+    setNavigator("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)");
+    expect(getExternalNavigationUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  test("getExternalNavigationUrl also recognizes iOS standalone flag but does not generate Android intents", () => {
+    setDisplayModeStandalone(false);
+    setNavigator("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)", true);
+
+    expect(getExternalNavigationUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  test("navigateExternalUrl delegates the resolved URL", () => {
+    setDisplayModeStandalone(true);
+    setNavigator("Mozilla/5.0 (Linux; Android 15)");
+    const navigate = jest.fn();
+
+    navigateExternalUrl("https://example.com", navigate);
+
+    expect(navigate).toHaveBeenCalledWith(expect.stringMatching(/^intent:\/\/example\.com\/#Intent;scheme=https;/));
+  });
+});

--- a/src/ts/modules/ExternalNavigator.ts
+++ b/src/ts/modules/ExternalNavigator.ts
@@ -1,0 +1,39 @@
+type Navigate = (url: string) => void;
+
+function isStandalonePwa(): boolean {
+  return Boolean(window.navigator.standalone) || Boolean(window.matchMedia?.("(display-mode: standalone)").matches);
+}
+
+function isAndroid(): boolean {
+  return /Android/i.test(window.navigator.userAgent);
+}
+
+export function getAndroidIntentUrl(url: string): string | false {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    return false;
+  }
+
+  const scheme = parsedUrl.protocol.slice(0, -1);
+  const target = `${parsedUrl.host}${parsedUrl.pathname}${parsedUrl.search}`;
+  const fallbackUrl = encodeURIComponent(url);
+  return `intent://${target}#Intent;scheme=${scheme};S.browser_fallback_url=${fallbackUrl};end`;
+}
+
+export function getExternalNavigationUrl(url: string): string {
+  if (typeof window === "undefined" || !isStandalonePwa() || !isAndroid()) {
+    return url;
+  }
+
+  return getAndroidIntentUrl(url) || url;
+}
+
+export function navigateExternalUrl(url: string, navigate: Navigate = (targetUrl) => window.location.assign(targetUrl)) {
+  navigate(getExternalNavigationUrl(url));
+}

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -12,6 +12,7 @@ import type { EnvParams, RedirectResponse } from "../types";
 import * as BSN from "bootstrap.native";
 import "bootstrap/dist/css/bootstrap.css";
 import countriesList from "countries-list";
+import { navigateExternalUrl } from "./ExternalNavigator";
 
 /** Set and manage the homepage. */
 
@@ -316,6 +317,10 @@ export default class Home {
       redirectUrl = response.redirectUrl as string;
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
+    }
+    if (response.status === "found") {
+      navigateExternalUrl(redirectUrl);
+      return;
     }
     window.location.href = redirectUrl;
   };


### PR DESCRIPTION
## Summary

Fixes target URL navigation from installed Android PWAs by routing successful shortcut redirects through Android `intent://` URLs, while preserving the existing in-app navigation for Trovu internal/error/debug flows.

This covers both redirect entry points:

- homepage query submission in `Home.submitQuery()`
- direct `/process/` handling in `CallHandler.handleCall()`

Non-Android browsers, normal Android browser tabs, iOS PWAs, `mailto:` targets, invalid URLs, and Trovu internal fallback redirects keep the existing navigation behavior.

Closes #329

## Verification

- `npx jest src/ts/modules/ExternalNavigator.test.ts src/ts/modules/CallHandler.test.ts --runInBand`
- `npm run lint-js -- --quiet`
- `npm run build`
- `npm run test-unit -- --runInBand`

/claim #329
