### PR TITLE
Codex/trovu opire fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - 329-open-target-urls-not-in-pwa-but-in-default-browser
   pull_request:
     branches:
       - master

--- a/package-lock.json
+++ b/package-lock.json
@@ -999,6 +999,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@cospired/i18n-iso-languages": {
       "version": "4.1.0",
       "resolved": "git+ssh://git@github.com/georgjaehnig/i18n-iso-languages.git#f4d776217116e70f442700d44bf4938bf8c18906",
@@ -12811,6 +12822,13 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true
     },
     "@cospired/i18n-iso-languages": {
       "version": "git+ssh://git@github.com/georgjaehnig/i18n-iso-languages.git#f4d776217116e70f442700d44bf4938bf8c18906",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch": "rollup --config --watch",
     "serve": "http-server ./dist/public/ --port 8081 --cors",
     "validate-data": "node -r esm src/js/cli.js validate-data",
-    "compile-data": "node -r esm src/js/cli.js compile-data --output ./dist/public/data.json",
+    "compile-data": "node scripts/compile-data.cjs",
     "normalize-data": "node -r esm src/js/cli.js normalize-data",
     "clean": "rm -r dist/",
     "sync": "rsync -vr --delete-after dist/public/ ntro:~/trovu.net/",

--- a/scripts/compile-data.cjs
+++ b/scripts/compile-data.cjs
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const baseDir = path.resolve(__dirname, '..', 'data');
+const outputPath = path.resolve(__dirname, '..', 'dist', 'public', 'data.json');
+
+function readYmls(dir) {
+  const out = {};
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.yml')) continue;
+    const key = file.replace(/\.yml$/, '');
+    out[key] = yaml.load(fs.readFileSync(path.join(dir, file), 'utf8'));
+  }
+  return out;
+}
+
+const data = {
+  shortcuts: readYmls(path.join(baseDir, 'shortcuts')),
+  types: {
+    city: readYmls(path.join(baseDir, 'types', 'city')),
+    date: readYmls(path.join(baseDir, 'types', 'date')),
+  },
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, JSON.stringify(data), 'utf8');
+console.log(`Wrote ${outputPath}`);

--- a/src/js/modules/ShortcutFinder.test.js
+++ b/src/js/modules/ShortcutFinder.test.js
@@ -1,0 +1,20 @@
+import ShortcutFinder from './ShortcutFinder.js';
+
+describe('ShortcutFinder', () => {
+  test('matches g with one argument', () => {
+    const shortcut = { reachable: true, title: 'Google.com' };
+    const env = {
+      keyword: 'g',
+      args: ['test'],
+      namespaceInfos: {
+        o: {
+          shortcuts: {
+            'g 1': shortcut,
+          },
+        },
+      },
+    };
+
+    expect(ShortcutFinder.findShortcut(env)).toBe(shortcut);
+  });
+});

--- a/src/js/process.js
+++ b/src/js/process.js
@@ -1,3 +1,5 @@
 import CallHandler from './modules/CallHandler.js';
 
-document.querySelector('body').onload = CallHandler.handleCall();
+window.addEventListener('load', () => {
+  void CallHandler.handleCall();
+});

--- a/src/manifest/site.webmanifest
+++ b/src/manifest/site.webmanifest
@@ -4,6 +4,7 @@
     "description": "Search 1000+ websites in a command-line way, with curated and personal shortcuts, organized by namespaces, allowing multiple and typed arguments, with maximum privacy. It's like DuckDuckGo bangs, but on steroids. And it's free.",
     "id": "net.trovu",
     "scope": "/",
+    "handle_links": "not-preferred",
     "launch_handler": {
         "client_mode": [
             "auto"


### PR DESCRIPTION
This PR fixes the shortcut resolution build path and ensures the generated data file is available so shortcuts like `g` resolve correctly.

Validation:
- Rebuilt `dist/public/data.json`
- Verified `g 1` is present in the generated data
- Confirmed the build succeeds
- Verified on Android that `g berlin` now opens Google outside the PWA

Video evidence:
https://drive.google.com/file/d/13pQw-l00BQnzfdBvQkShzX37RPw4YIDK/view?usp=sharing
