### PR TITLE
fix: open target search urls in default browser when running in standalone PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,12 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    if (env.isRunningStandalone()) {
+      window.open(redirectUrl, "_blank");
+      window.location.replace("../index.html");
+    } else {
+      window.location.replace(redirectUrl);
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -314,6 +314,12 @@ export default class Home {
     let redirectUrl: string;
     if (response.status === "found") {
       redirectUrl = response.redirectUrl as string;
+      if (envQuery.isRunningStandalone()) {
+        window.open(redirectUrl, "_blank");
+        this.queryInput.value = "";
+        this.toggleByQuery();
+        return;
+      }
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }


### PR DESCRIPTION
### Description
This PR ensures that when Trovu is run as a Progressive Web App (PWA) in standalone mode, target search URLs are opened in the user's default system browser via \window.open(..., '_blank')\ instead of navigating inside the standalone window container.

Closes #329

/opire claim #329