### PR TITLE
Fix #329

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -49,6 +49,32 @@ describe("CallHandler", () => {
   test("isSafeRedirectUrl blocks unparseable URLs", () => {
     expect(CallHandler.isSafeRedirectUrl("not a url")).toBe(false);
   });
+  test("getAndroidIntentUrl converts http and https URLs on Android", () => {
+    jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+
+    expect(CallHandler.getAndroidIntentUrl("https://www.google.com/search?q=trovu")).toBe(
+      "intent://www.google.com/search?q=trovu#Intent;scheme=https;action=android.intent.action.VIEW;end",
+    );
+    expect(CallHandler.getAndroidIntentUrl("http://example.com/path")).toBe(
+      "intent://example.com/path#Intent;scheme=http;action=android.intent.action.VIEW;end",
+    );
+
+    jest.restoreAllMocks();
+  });
+  test("getAndroidIntentUrl does not convert non-web URLs", () => {
+    jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+
+    expect(CallHandler.getAndroidIntentUrl("mailto:test@example.com")).toBe(false);
+
+    jest.restoreAllMocks();
+  });
+  test("getAndroidIntentUrl only converts on Android", () => {
+    jest.spyOn(CallHandler, "isAndroid").mockReturnValue(false);
+
+    expect(CallHandler.getAndroidIntentUrl("https://www.google.com/search?q=trovu")).toBe(false);
+
+    jest.restoreAllMocks();
+  });
   test("getRedirectResponse returns suspicious for blocked redirect URLs", () => {
     const shortcutSpy = jest.spyOn(ShortcutFinder, "findShortcut").mockReturnValue({
       url: "javascript:alert(1)",

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,6 +45,11 @@ export default class CallHandler {
       return;
     }
 
+    if (response.status === "found") {
+      this.openTargetUrl(redirectUrl, "replace");
+      return;
+    }
+
     window.location.replace(redirectUrl);
   }
 
@@ -130,6 +135,63 @@ export default class CallHandler {
       return false;
     }
     return ["http:", "https:", "mailto:"].includes(parsedUrl.protocol);
+  }
+
+  static openTargetUrl(redirectUrl: string, fallback: "href" | "replace" = "href"): void {
+    if (this.isStandalonePwa()) {
+      const androidIntentUrl = this.getAndroidIntentUrl(redirectUrl);
+      if (androidIntentUrl) {
+        window.location.href = androidIntentUrl;
+        return;
+      }
+
+      const openedWindow = window.open(redirectUrl, "_blank", "noopener,noreferrer");
+      if (openedWindow) {
+        return;
+      }
+    }
+
+    if (fallback === "replace") {
+      window.location.replace(redirectUrl);
+      return;
+    }
+
+    window.location.href = redirectUrl;
+  }
+
+  static isStandalonePwa(): boolean {
+    const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+    const isStandaloneDisplayMode =
+      typeof window.matchMedia === "function" && window.matchMedia("(display-mode: standalone)").matches;
+    return isStandaloneDisplayMode || navigatorWithStandalone.standalone === true;
+  }
+
+  static isAndroid(): boolean {
+    const userAgentData = navigator as Navigator & { userAgentData?: { platform?: string } };
+    const platform = userAgentData.userAgentData?.platform || navigator.platform || "";
+    return /android/i.test(platform) || /android/i.test(navigator.userAgent);
+  }
+
+  static getAndroidIntentUrl(redirectUrl: string): string | false {
+    if (!this.isAndroid()) {
+      return false;
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(redirectUrl);
+    } catch {
+      return false;
+    }
+
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      return false;
+    }
+
+    const scheme = parsedUrl.protocol.slice(0, -1);
+    const encodedHash = parsedUrl.hash ? "%23" + encodeURIComponent(parsedUrl.hash.slice(1)) : "";
+    const path = `${parsedUrl.host}${parsedUrl.pathname}${parsedUrl.search}${encodedHash}`;
+    return `intent://${path}#Intent;scheme=${scheme};action=android.intent.action.VIEW;end`;
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -317,6 +317,11 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
+    if (response.status === "found") {
+      CallHandler.openTargetUrl(redirectUrl);
+      return;
+    }
+
     window.location.href = redirectUrl;
   };
 


### PR DESCRIPTION
## Fix for #329\n\nImplemented the PWA external-opening fix.\n\nChanged:\n- [CallHandler.ts](/tmp/bounty-trovu_329-fusaufjk/repo/src/ts/modules/CallHandler.ts:48): resolved target URLs now go through shared .\n- [Home.ts](/tmp/bounty-trovu_329-fusaufjk/repo/src/ts/modules/Home.ts:320): homepage shortcut submissions use the same target-opening path.\n- [CallHandler.test.ts](/tmp/bounty-trovu_329-fusaufjk/repo/src/ts/modules/CallHandler.test.ts:52): added Android intent URL coverage.\n\nBehavior:\n- In an And\n\nPlease review and let me know if any changes are needed.