### PR TITLE
Show target domains in shortcut suggestions

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -93,7 +93,8 @@ span.title {
   margin: 0 0.1em;
 }
 span.namespace,
-span.tag {
+span.tag,
+span.domain {
   display: inline-block;
   padding: 0.05em 0.4em;
   border-radius: 0.2rem;
@@ -114,6 +115,10 @@ div.tags {
 span.tag {
   background: var(--bs-yellow);
   color: black;
+}
+span.domain {
+  background: #487b7fff;
+  color: white;
 }
 span.highlight {
   margin: 0 -0.4em;

--- a/src/ts/modules/home/Suggestions.test.ts
+++ b/src/ts/modules/home/Suggestions.test.ts
@@ -64,4 +64,29 @@ describe("Suggestions", () => {
     expect(element.querySelector(".tag")?.textContent).toBe(payload);
     expect(element.querySelector(".examples .description")?.textContent).toBe(payload);
   });
+
+  test("renders the target domain as a clickable url filter badge", () => {
+    const renderer = createRenderer();
+    const element = renderer.renderSuggestion(
+      {
+        namespace: "evil",
+        keyword: "ex",
+        argumentString: "",
+        argumentCount: 0,
+        title: "Example",
+        description: "Example homepage",
+        url: "https://example.com/search",
+        reachable: true,
+      },
+      0,
+    ) as HTMLElement;
+
+    const domainBadge = element.querySelector(".domain") as HTMLElement;
+    expect(domainBadge.textContent).toBe("example.com");
+
+    domainBadge.click();
+
+    expect(renderer.queryInput.value).toBe("url:example.com");
+    expect(document.activeElement).toBe(renderer.queryInput);
+  });
 });

--- a/src/ts/modules/home/Suggestions.ts
+++ b/src/ts/modules/home/Suggestions.ts
@@ -157,27 +157,28 @@ export default class Suggestions {
   }
 
   getBadges(suggestion: Suggestion): HTMLElement {
-    const { tags } = suggestion;
     const container = document.createElement("div");
     container.className = "tags";
-    const domain = suggestion.url.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]+)/i)?.[1];
-    if (domain) {
-      container.appendChild(this.createSpan("domain", domain));
-    }
-    if (Array.isArray(tags) && tags.length) {
-      tags.forEach((tag) => {
-        container.appendChild(this.createSpan("tag", tag));
-      });
-    }
-    container.addEventListener("click", (e: Event) => {
-      const target = e.target as HTMLElement;
-      if (target.classList.contains("tag")) {
-        this.handleTagOrNamespaceClick(e, `tag:${target.textContent}`);
-      } else if (target.classList.contains("domain")) {
-        this.handleTagOrNamespaceClick(e, `url:${target.textContent}`);
-      }
-    });
+    container.append(this.getDomain(suggestion), ...this.getTags(suggestion));
     return container;
+  }
+
+  getDomain(suggestion: Suggestion): HTMLSpanElement | string {
+    const domain = suggestion.url.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]+)/i)?.[1];
+    return domain ? this.createFilterBadge("domain", domain, "url") : "";
+  }
+
+  getTags({ tags }: Suggestion): HTMLSpanElement[] {
+    if (!Array.isArray(tags)) return [];
+    return tags.map((tag) => this.createFilterBadge("tag", tag, "tag"));
+  }
+
+  createFilterBadge(className: string, text: string, queryPrefix: string): HTMLSpanElement {
+    const badge = this.createSpan(className, text);
+    badge.addEventListener("click", (event) => {
+      this.handleTagOrNamespaceClick(event, `${queryPrefix}:${text}`);
+    });
+    return badge;
   }
 
   getExamples(suggestion: Suggestion): HTMLElement | DocumentFragment {

--- a/src/ts/modules/home/Suggestions.ts
+++ b/src/ts/modules/home/Suggestions.ts
@@ -159,7 +159,7 @@ export default class Suggestions {
   getBadges(suggestion: Suggestion): HTMLElement {
     const container = document.createElement("div");
     container.className = "tags";
-    container.append(this.getDomain(suggestion), ...this.getTags(suggestion));
+    container.append(...this.getTags(suggestion), this.getDomain(suggestion));
     return container;
   }
 

--- a/src/ts/modules/home/Suggestions.ts
+++ b/src/ts/modules/home/Suggestions.ts
@@ -1,10 +1,10 @@
 /** @module Suggestions */
+import type { EnvLike, ShortcutExample, Suggestion } from "../../types";
+import type Home from "../Home";
 import QueryParser from "../QueryParser";
 import SuggestionsGetter from "../SuggestionsGetter";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import jsyaml from "js-yaml";
-import type { EnvLike, ShortcutExample, Suggestion } from "../../types";
-import type Home from "../Home";
 
 export default class Suggestions {
   env: EnvLike;

--- a/src/ts/modules/home/Suggestions.ts
+++ b/src/ts/modules/home/Suggestions.ts
@@ -106,7 +106,7 @@ export default class Suggestions {
       this.getUrl(suggestion),
       this.hasTag(suggestion, "needs-userscript") ? this.getNeedsUserscript() : "",
       this.hasTag(suggestion, "is-affiliate") ? this.getIsAffiliate() : "",
-      this.getTags(suggestion),
+      this.getBadges(suggestion),
       this.getTools(suggestion),
     );
 
@@ -156,21 +156,25 @@ export default class Suggestions {
     return container;
   }
 
-  getTags(suggestion: Suggestion): HTMLElement | string {
+  getBadges(suggestion: Suggestion): HTMLElement {
     const { tags } = suggestion;
     const container = document.createElement("div");
     container.className = "tags";
+    const domain = suggestion.url.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]+)/i)?.[1];
+    if (domain) {
+      container.appendChild(this.createSpan("domain", domain));
+    }
     if (Array.isArray(tags) && tags.length) {
       tags.forEach((tag) => {
         container.appendChild(this.createSpan("tag", tag));
       });
-    } else {
-      return "";
     }
     container.addEventListener("click", (e: Event) => {
       const target = e.target as HTMLElement;
       if (target.classList.contains("tag")) {
         this.handleTagOrNamespaceClick(e, `tag:${target.textContent}`);
+      } else if (target.classList.contains("domain")) {
+        this.handleTagOrNamespaceClick(e, `url:${target.textContent}`);
       }
     });
     return container;


### PR DESCRIPTION
- show the target URL domain as a badge alongside suggestion tags
- style domain badges with a petrol background and white text
- make domain badges clickable to apply the existing `url:` filter
- separate domain and tag rendering while sharing common badge logic

Closes #188 