### PR TITLE
Improve homepage startup and show shortcut loading state

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - codex/homepage-startup
   pull_request:
     branches:
       - master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - codex/homepage-startup
   pull_request:
     branches:
       - master

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" aria-busy="true">
   <head>
     <head>
       <meta charset="utf-8" />
@@ -195,9 +195,7 @@
               placeholder="keyword arg1, arg2…"
             />
             <div class="input-group-append">
-              <button type="submit" class="btn btn-primary" aria-label="Search">
-                <i class="fas fa-caret-right" aria-hidden="true"></i>
-              </button>
+              <button type="submit" class="btn btn-loading" aria-label="Shortcuts are loading">⏳</button>
             </div>
           </div>
         </form>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -195,7 +195,7 @@
               placeholder="keyword arg1, arg2…"
             />
             <div class="input-group-append">
-              <button type="submit" class="btn btn-primary">
+              <button type="submit" class="btn btn-primary" aria-label="Search">
                 <i class="fas fa-caret-right" aria-hidden="true"></i>
               </button>
             </div>

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -84,6 +84,11 @@ main .jumbotron {
 #query-form {
   button[type="submit"] {
     font-size: 1.4em;
+    min-width: 2em;
+    &.btn-loading {
+      background-color: #ddd;
+      color: white;
+    }
   }
 }
 #query {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,4 @@
 import Home from "./modules/Home";
 
 const home = new Home();
-document.querySelector("body").onload = () => home.initialize();
+home.initialize();

--- a/src/ts/modules/Env.test.ts
+++ b/src/ts/modules/Env.test.ts
@@ -20,6 +20,7 @@ const minimalData = {
 
 afterEach(() => {
   global.fetch = originalFetch;
+  localStorage.clear();
   Object.defineProperty(Intl, "Locale", {
     configurable: true,
     value: originalIntlLocale,
@@ -256,6 +257,47 @@ describe("Env", () => {
       });
       expect(env.reload).toBeUndefined();
       expect(env.query).toBe("g foo");
+    });
+
+    test("loads a stored GitHub config in parallel with the initial data fetch", async () => {
+      let resolveData: (response: Response) => void;
+      const dataResponse = {
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify(minimalData)),
+      } as unknown as Response;
+      const configResponse = {
+        status: 200,
+        text: jest.fn().mockResolvedValue("defaultKeyword: g"),
+      } as unknown as Response;
+      const fetchMock = jest.fn((url: string) => {
+        if (url.startsWith("/data.json")) {
+          return new Promise<Response>((resolve) => {
+            resolveData = resolve;
+          });
+        }
+        if (url === "https://raw.githubusercontent.com/johndoe/trovu-data-user/master/config.yml") {
+          return Promise.resolve(configResponse);
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+      global.fetch = fetchMock as typeof fetch;
+      jest.spyOn(Env, "fetchLog").mockImplementation(() => {});
+      jest.spyOn(NamespaceFetcher.prototype, "getNamespaceInfos").mockResolvedValue({});
+      localStorage.setItem("github", "johndoe");
+
+      const env = new Env({ context: "index" });
+      const populatePromise = env.populate({});
+      await Promise.resolve();
+
+      expect(fetchMock).toHaveBeenCalledWith("https://raw.githubusercontent.com/johndoe/trovu-data-user/master/config.yml", {
+        cache: "force-cache",
+        signal: expect.any(AbortSignal),
+      });
+      resolveData(dataResponse);
+      await populatePromise;
+
+      expect(env.github).toBe("johndoe");
+      expect(env.defaultKeyword).toBe("g");
     });
   });
 });

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -1,5 +1,5 @@
 /** @module Env */
-import Helper from "./Helper";
+import Helper, { REMOTE_FETCH_TIMEOUT } from "./Helper";
 import Logger from "./Logger";
 import NamespaceFetcher from "./NamespaceFetcher";
 import QueryParser from "./QueryParser";
@@ -174,7 +174,19 @@ export default class Env {
     Object.assign(this, preloadParams);
     this.configureLogger();
 
-    this.data = this.data || (await this.getData()) || ({} as TrovuData);
+    this.getFromLocalStorage();
+
+    if (typeof this.github === "string" && this.github !== "") {
+      this.configUrl = this.buildGithubConfigUrl(this.github);
+    }
+    if (typeof params.configUrl === "string" && params.configUrl !== "") {
+      this.configUrl = params.configUrl;
+    }
+
+    const dataPromise = this.data ? Promise.resolve(this.data) : this.getData();
+    const configPromise = this.configUrl ? this.getUserConfigFromUrl(this.configUrl) : Promise.resolve(undefined);
+    const [data, config] = await Promise.all([dataPromise, configPromise]);
+    this.data = data || ({} as TrovuData);
 
     // Raycast cannot handle too much data.
     if (options && options.removeNamespaces) {
@@ -189,19 +201,8 @@ export default class Env {
       this.defaultKeyword = this.data.config.defaultKeyword;
     }
 
-    this.getFromLocalStorage();
-
-    if (typeof params.github === "string" && params.github !== "") {
-      this.configUrl = this.buildGithubConfigUrl(params.github);
-    }
-    if (typeof params.configUrl === "string" && params.configUrl !== "") {
-      this.configUrl = params.configUrl;
-    }
-    if (this.configUrl) {
-      const config = await this.getUserConfigFromUrl(this.configUrl);
-      if (config) {
-        Object.assign(this, config);
-      }
+    if (config) {
+      Object.assign(this, config);
     }
     // Assign again, to override user config.
     Object.assign(this, params);
@@ -338,7 +339,10 @@ export default class Env {
    */
 
   async getUserConfigFromUrl(configUrl: string): Promise<TrovuConfig | undefined> {
-    const configYml = await Helper.fetchAsync(configUrl, this);
+    const configYml = await Helper.fetchAsync(configUrl, this, {
+      catchErrors: true,
+      timeout: REMOTE_FETCH_TIMEOUT,
+    });
     if (!configYml) {
       this.logger.warning(`Problem reading config from ${configUrl}`);
     }

--- a/src/ts/modules/Helper.test.ts
+++ b/src/ts/modules/Helper.test.ts
@@ -5,6 +5,7 @@ describe("Helper.fetchAsync", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -40,7 +41,7 @@ describe("Helper.fetchAsync", () => {
       text: jest.fn(),
     } as unknown as Response);
 
-    const text = await Helper.fetchAsync("https://example.com/missing.txt", { reload: false, logger });
+    const text = await Helper.fetchAsync("https://example.com/missing.txt", { reload: false, logger }, { catchErrors: true });
 
     expect(global.fetch).toHaveBeenCalledWith("https://example.com/missing.txt", {
       cache: "force-cache",
@@ -48,5 +49,47 @@ describe("Helper.fetchAsync", () => {
     expect(text).toBeNull();
     expect(logger.info).toHaveBeenCalledWith("Problem fetching via force-cache https://example.com/missing.txt: 404");
     expect(logger.success).not.toHaveBeenCalled();
+  });
+
+  test("returns null and logs a warning for a network error", async () => {
+    const logger = {
+      info: jest.fn(),
+      success: jest.fn(),
+      warning: jest.fn(),
+    };
+    global.fetch = jest.fn().mockRejectedValue(new Error("offline"));
+
+    const text = await Helper.fetchAsync(
+      "https://example.com/missing.txt",
+      { reload: false, logger },
+      { catchErrors: true },
+    );
+
+    expect(text).toBeNull();
+    expect(logger.warning).toHaveBeenCalledWith("Problem fetching via force-cache https://example.com/missing.txt: offline");
+  });
+
+  test("aborts a request after the configured timeout", async () => {
+    jest.useFakeTimers();
+    const logger = {
+      info: jest.fn(),
+      success: jest.fn(),
+      warning: jest.fn(),
+    };
+    global.fetch = jest.fn((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        options.signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+
+    const textPromise = Helper.fetchAsync(
+      "https://example.com/slow.txt",
+      { reload: false, logger },
+      { catchErrors: true, timeout: 5000 },
+    );
+    jest.advanceTimersByTime(5000);
+
+    await expect(textPromise).resolves.toBeNull();
+    expect(logger.warning).toHaveBeenCalledWith("Problem fetching via force-cache https://example.com/slow.txt: aborted");
   });
 });

--- a/src/ts/modules/Helper.ts
+++ b/src/ts/modules/Helper.ts
@@ -2,6 +2,8 @@
 
 /** Helper methods. */
 
+export const REMOTE_FETCH_TIMEOUT = 5000;
+
 export default class Helper {
   /**
    * Fetch the content of a file behind an URL.
@@ -13,17 +15,46 @@ export default class Helper {
    *
    * @return {string} text  - The content.
    */
-  static async fetchAsync(url, env) {
-    const requestCache = env.reload ? "reload" : "force-cache";
-    const response = await fetch(url, {
-      cache: requestCache,
-    });
-    if (response.status !== 200) {
-      env.logger.info(`Problem fetching via ${requestCache} ${url}: ${response.status}`);
+  static async fetchAsync(url, env, options: { cache?: RequestCache; catchErrors?: boolean; timeout?: number } = {}) {
+    const response = await this.fetchResponse(url, env, options);
+    if (!response) {
       return null;
     }
+    const requestCache = options.cache || (env.reload ? "reload" : "force-cache");
     env.logger.success(`Success fetching via ${requestCache} ${url}`);
     const text = await response.text();
     return text;
+  }
+
+  static async fetchResponse(url, env, options: { cache?: RequestCache; catchErrors?: boolean; timeout?: number } = {}) {
+    const requestCache = options.cache || (env.reload ? "reload" : "force-cache");
+    const controller = options.timeout ? new AbortController() : undefined;
+    const timeoutId = options.timeout ? setTimeout(() => controller?.abort(), options.timeout) : undefined;
+    try {
+      const response = await fetch(url, {
+        cache: requestCache,
+        ...(controller ? { signal: controller.signal } : {}),
+      });
+      if (!response) {
+        env.logger.info(`Problem fetching via ${requestCache} ${url}`);
+        return null;
+      }
+      if (response.status !== 200) {
+        env.logger.info(`Problem fetching via ${requestCache} ${url}: ${response.status}`);
+        return null;
+      }
+      return response;
+    } catch (error) {
+      if (!options.catchErrors) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      env.logger.warning(`Problem fetching via ${requestCache} ${url}: ${message}`);
+      return null;
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -102,8 +102,9 @@ export default class Home {
     this.queryInput.addEventListener("input", () => {
       this.queryInputChanged = true;
     });
-    document.documentElement.style.display = "block";
     this.setLoadingState(true);
+    this.toggleByQuery();
+    document.documentElement.style.display = "block";
     this.queryInput.focus();
     if (params.status === "loading") {
       this.showInfoAlerts();

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -212,7 +212,7 @@ export default class Home {
 
   setLocationHash() {
     const paramStr = this.env.buildUrlParamStr();
-    window.location.hash = "#" + paramStr;
+    window.history.replaceState(null, "", "#" + paramStr);
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -5,7 +5,6 @@ import Env from "./Env";
 import GitLogger from "./GitLogger";
 import Settings from "./home/Settings";
 import Suggestions from "./home/Suggestions";
-import "@fortawesome/fontawesome-free/js/all.min";
 import type { EnvParams, RedirectResponse } from "../types";
 
 /* eslint-disable no-unused-vars */

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -70,7 +70,7 @@ export default class Home {
       });
     }
     this.initialized = true;
-    this.setLoadingState(false);
+    this.showReadyState();
     document.documentElement.setAttribute("data-page-loaded", "true");
 
     Home.setHeights();
@@ -102,7 +102,6 @@ export default class Home {
     this.queryInput.addEventListener("input", () => {
       this.queryInputChanged = true;
     });
-    this.setLoadingState(true);
     this.toggleByQuery();
     document.documentElement.style.display = "block";
     this.queryInput.focus();
@@ -111,18 +110,9 @@ export default class Home {
     }
   }
 
-  setLoadingState(isLoading: boolean) {
-    if (isLoading) {
-      document.documentElement.setAttribute("aria-busy", "true");
-      this.submitButton.classList.remove("btn-primary");
-      this.submitButton.classList.add("btn-secondary");
-      this.submitButton.setAttribute("aria-label", "Shortcuts are loading");
-      this.submitButton.textContent = "\u23f3";
-      return;
-    }
-
+  showReadyState() {
     document.documentElement.removeAttribute("aria-busy");
-    this.submitButton.classList.remove("btn-secondary");
+    this.submitButton.classList.remove("btn-loading");
     this.submitButton.classList.add("btn-primary");
     this.submitButton.setAttribute("aria-label", "Search");
     const icon = document.createElement("i");

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -18,6 +18,9 @@ export default class Home {
   env!: Env;
   queryInput!: HTMLInputElement;
   suggestions!: Suggestions;
+  submitButton!: HTMLButtonElement;
+  initialized = false;
+  queryInputChanged = false;
 
   constructor() {}
 
@@ -32,6 +35,8 @@ export default class Home {
 
     // Init environment.
     const params = Env.getParamsFromUrl();
+    this.setQueryElementValue(params);
+    this.prepareLoadingUi(params);
     await this.env.populate(params);
     this.updateOpensearch();
 
@@ -47,8 +52,8 @@ export default class Home {
 
     new Settings(this.env, this.updateOpensearch);
 
-    this.showInfoAlerts();
     this.setLocationHash();
+    this.showInfoAlerts();
     this.setQueryElement();
 
     // Toggle by query only after the query input is set.
@@ -58,16 +63,14 @@ export default class Home {
       this.env.logger.showLog();
     }
 
-    const queryForm = document.getElementById("query-form") as HTMLFormElement | null;
-    if (queryForm) {
-      queryForm.onsubmit = this.submitQuery;
-    }
     const reloadLink = document.querySelector<HTMLAnchorElement>("#reload");
     if (reloadLink) {
       reloadLink.href = this.env.buildProcessUrl({
         query: "reload",
       });
     }
+    this.initialized = true;
+    this.setLoadingState(false);
     document.documentElement.setAttribute("data-page-loaded", "true");
 
     Home.setHeights();
@@ -86,6 +89,45 @@ export default class Home {
         queryElement?.focus();
       }
     });
+  }
+
+  prepareLoadingUi(params: EnvParams) {
+    const queryForm = document.getElementById("query-form") as HTMLFormElement | null;
+    const submitButton = queryForm?.querySelector<HTMLButtonElement>('button[type="submit"]');
+    if (!queryForm || !submitButton) {
+      throw new Error('Missing element "#query-form" or its submit button.');
+    }
+    this.submitButton = submitButton;
+    queryForm.onsubmit = this.submitQuery;
+    this.queryInput.addEventListener("input", () => {
+      this.queryInputChanged = true;
+    });
+    document.documentElement.style.display = "block";
+    this.setLoadingState(true);
+    this.queryInput.focus();
+    if (params.status === "loading") {
+      this.showInfoAlerts();
+    }
+  }
+
+  setLoadingState(isLoading: boolean) {
+    if (isLoading) {
+      document.documentElement.setAttribute("aria-busy", "true");
+      this.submitButton.classList.remove("btn-primary");
+      this.submitButton.classList.add("btn-secondary");
+      this.submitButton.setAttribute("aria-label", "Shortcuts are loading");
+      this.submitButton.textContent = "\u23f3";
+      return;
+    }
+
+    document.documentElement.removeAttribute("aria-busy");
+    this.submitButton.classList.remove("btn-secondary");
+    this.submitButton.classList.add("btn-primary");
+    this.submitButton.setAttribute("aria-label", "Search");
+    const icon = document.createElement("i");
+    icon.className = "fas fa-caret-right";
+    icon.setAttribute("aria-hidden", "true");
+    this.submitButton.replaceChildren(icon);
   }
 
   static setHeights() {
@@ -129,20 +171,26 @@ export default class Home {
   }
 
   setQueryElement() {
-    switch (this.env.status) {
+    if (!this.queryInputChanged) {
+      this.setQueryElementValue(this.env);
+    }
+
+    this.suggestions = new Suggestions("#query", "#suggestions", this);
+    this.setToggleByQuery();
+  }
+
+  setQueryElementValue(params: EnvParams) {
+    switch (params.status) {
       case "deprecated":
-        this.queryInput.value = this.env.alternative;
+        this.queryInput.value = params.alternative || "";
         break;
       case "reloaded":
         this.queryInput.value = "";
         break;
       default:
-        this.queryInput.value = this.env.query || "";
+        this.queryInput.value = params.query || "";
         break;
     }
-
-    this.suggestions = new Suggestions("#query", "#suggestions", this);
-    this.setToggleByQuery();
   }
 
   setToggleByQuery() {
@@ -211,7 +259,9 @@ export default class Home {
   }
 
   setLocationHash() {
-    const paramStr = this.env.buildUrlParamStr();
+    const params = Env.getParamsFromUrl();
+    const moreParams = params.status === "loading" ? { query: params.query, status: params.status } : {};
+    const paramStr = this.env.buildUrlParamStr(moreParams);
     window.history.replaceState(null, "", "#" + paramStr);
   }
 
@@ -229,10 +279,21 @@ export default class Home {
     if (!alertMsg || !alertClose) {
       return;
     }
-    alertClose.addEventListener("click", () => {
+    alert.setAttribute("hidden", "");
+    alertMsg.textContent = "";
+    alertClose.onclick = () => {
+      if (!this.initialized) {
+        const params = Env.getUrlSearchParams();
+        params.delete("query");
+        params.delete("status");
+        params.sort();
+        window.history.replaceState(null, "", "#" + params.toString());
+        alert.setAttribute("hidden", "");
+        return;
+      }
       const paramStr = this.env.buildUrlParamStr({ query: undefined, status: undefined });
       window.location.hash = "#" + paramStr;
-    });
+    };
     if (params.status) {
       alert.removeAttribute("hidden");
     }
@@ -254,6 +315,10 @@ export default class Home {
           alertMsg.innerHTML +=
             " Changes on your GitHub might require a reload in <strong>5 minutes</strong> due to caching.";
         }
+        break;
+      case "loading":
+        alertMsg.textContent =
+          "Shortcuts were still loading when you submitted. Wait until the arrow appears, then submit your query again.";
         break;
       case "deprecated":
         alertMsg.innerHTML = 'Your shortcut <strong><em class="query"></em></strong> is deprecated. Please use:';
@@ -291,6 +356,11 @@ export default class Home {
       event.preventDefault();
     }
 
+    if (!this.initialized) {
+      this.showLoadingSubmitStatus();
+      return;
+    }
+
     // Must create new env instance here,
     // because extraNamespace might have changed reachability,
     // or asking for a not yet parsed Github namespace.
@@ -318,6 +388,15 @@ export default class Home {
     }
     window.location.href = redirectUrl;
   };
+
+  showLoadingSubmitStatus() {
+    const params = Env.getUrlSearchParams();
+    params.set("query", this.queryInput.value);
+    params.set("status", "loading");
+    params.sort();
+    window.history.replaceState(null, "", "#" + params.toString());
+    this.showInfoAlerts();
+  }
 
   /**
    * On triggering reload

--- a/src/ts/modules/NamespaceFetcher.test.ts
+++ b/src/ts/modules/NamespaceFetcher.test.ts
@@ -173,6 +173,36 @@ describe("NamespaceFetcher.addNamespaceInfo", () => {
 });
 
 describe("NamespaceFetcher.fetchNamespaceInfos", () => {
+  test("continues with an empty namespace after a network error", async () => {
+    const logger = {
+      error: jest.fn(),
+      info: jest.fn(),
+      success: jest.fn(),
+      warning: jest.fn(),
+    };
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockRejectedValue(new Error("offline"));
+    const fetcher = new NamespaceFetcher({ logger });
+    const namespaceInfos = {
+      johndoe: {
+        name: "johndoe",
+        type: "user" as const,
+        url: "https://example.com/shortcuts.yml",
+      },
+    };
+
+    await expect(fetcher.fetchNamespaceInfos(namespaceInfos)).resolves.toEqual({
+      johndoe: {
+        ...namespaceInfos.johndoe,
+        shortcuts: {},
+      },
+    });
+    expect(logger.warning).toHaveBeenCalledWith(
+      "Problem fetching via default https://example.com/shortcuts.yml: offline",
+    );
+    global.fetch = originalFetch;
+  });
+
   test("with endless new user namespaces (negative)", async () => {
     const fetcher = new NamespaceFetcher(new Env({}));
     const namespaceInfos = {

--- a/src/ts/modules/NamespaceFetcher.ts
+++ b/src/ts/modules/NamespaceFetcher.ts
@@ -1,4 +1,5 @@
 /** @module NamespaceFetcher */
+import Helper, { REMOTE_FETCH_TIMEOUT } from "./Helper";
 import ShortcutVerifier from "./ShortcutVerifier";
 import UrlProcessor from "./UrlProcessor";
 import jsyaml from "js-yaml";
@@ -208,15 +209,17 @@ export default class NamespaceFetcher {
    * @param {array} newNamespaceInfos - The namespaces to fetch shortcuts for.
    * @return {array} promises - The promises from the fetch() calls.
    */
-  startFetches(newNamespaceInfos: NamespaceInfo[]): Promise<Response>[] {
-    const promises: Promise<Response>[] = [];
+  startFetches(newNamespaceInfos: NamespaceInfo[]): Promise<Response | null>[] {
+    const promises: Promise<Response | null>[] = [];
     for (const namespaceInfo of newNamespaceInfos) {
       // Skip namespaces without URL.
       if (!namespaceInfo.url) {
         continue;
       }
-      const promise = fetch(namespaceInfo.url, {
+      const promise = Helper.fetchResponse(namespaceInfo.url, this.env, {
         cache: this.env.reload ? "reload" : "default",
+        catchErrors: true,
+        timeout: REMOTE_FETCH_TIMEOUT,
       });
       promises.push(promise);
     }
@@ -229,15 +232,14 @@ export default class NamespaceFetcher {
    * @param {Array} responses - An array of responses to process.
    * @returns {Object} The updated namespace information object.
    */
-  async processResponses(newNamespaceInfos: NamespaceInfo[], responses: Response[]): Promise<NamespaceInfo[]> {
+  async processResponses(newNamespaceInfos: NamespaceInfo[], responses: (Response | null)[]): Promise<NamespaceInfo[]> {
     for (const namespaceInfo of newNamespaceInfos) {
       // Skip namespaces without URL.
       if (!namespaceInfo.url) {
         continue;
       }
       const response = responses.shift();
-      if (!response || response.status != 200) {
-        this.env.logger.info(`Problem fetching via ${this.env.reload ? "reload" : "default"} ${namespaceInfo.url}`);
+      if (!response) {
         namespaceInfo.shortcuts = {};
         continue;
       }

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -214,6 +214,7 @@ export type RedirectStatus =
   | "removed"
   | "not_reachable"
   | "reloaded"
+  | "loading"
   | "suspicious";
 
 export interface RedirectResponse {

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -36,6 +36,23 @@ test("Homepage startup should not reload after normalizing the hash", async ({ p
   expect(navigationRequests).toBe(1);
 });
 
+test("Homepage HTML should expose a loading state before JavaScript runs", async ({ page }) => {
+  await page.route("**/*", async (route) => {
+    if (route.request().resourceType() === "script") {
+      await route.abort();
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  const submitButton = page.locator('#query-form button[type="submit"]');
+  await expect(page.locator("html")).toHaveAttribute("aria-busy", "true");
+  await expect(submitButton).toHaveClass(/btn-loading/);
+  await expect(submitButton).toHaveAttribute("aria-label", "Shortcuts are loading");
+  await expect(submitButton).toHaveText("⏳");
+});
+
 test("Homepage should expose a loading state and reject an early submit", async ({ page }) => {
   let resumeData;
   let shouldDelayData = true;
@@ -58,9 +75,10 @@ test("Homepage should expose a loading state and reject an early submit", async 
     await expect(queryInput).toBeFocused();
     await expect(page.locator(".tagline")).toBeVisible();
     await expect(page.locator(".examples")).toBeVisible();
-    await expect(submitButton).toHaveClass(/btn-secondary/);
+    await expect(submitButton).toHaveClass(/btn-loading/);
     await expect(submitButton).toHaveAttribute("aria-label", "Shortcuts are loading");
     await expect(submitButton).toHaveText("⏳");
+    await expect(submitButton).toHaveCSS("background-color", "rgb(192, 192, 192)");
 
     await queryInput.fill("debug:g foobar");
     await queryInput.press("Enter");

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -36,6 +36,81 @@ test("Homepage startup should not reload after normalizing the hash", async ({ p
   expect(navigationRequests).toBe(1);
 });
 
+test("Homepage should expose a loading state and reject an early submit", async ({ page }) => {
+  let resumeData;
+  let shouldDelayData = true;
+  await page.route("**/data.json?*", async (route) => {
+    if (!shouldDelayData) {
+      await route.continue();
+      return;
+    }
+    await new Promise((resolve) => {
+      resumeData = resolve;
+    });
+    await route.continue();
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  const queryInput = page.locator("#query");
+  const submitButton = page.locator('#query-form button[type="submit"]');
+  try {
+    await expect(page.locator("html")).toHaveAttribute("aria-busy", "true");
+    await expect(queryInput).toBeFocused();
+    await expect(submitButton).toHaveClass(/btn-secondary/);
+    await expect(submitButton).toHaveAttribute("aria-label", "Shortcuts are loading");
+    await expect(submitButton).toHaveText("⏳");
+
+    await queryInput.fill("debug:g foobar");
+    await queryInput.press("Enter");
+    await expect(page).toHaveURL(/query=debug%3Ag\+foobar/);
+    await expect(page).toHaveURL(/status=loading/);
+    await expect(page.locator("#alert")).toContainText("Shortcuts were still loading when you submitted.");
+  } finally {
+    shouldDelayData = false;
+    resumeData?.();
+  }
+
+  await expect(page.locator('[data-page-loaded="true"]')).toBeVisible();
+  await expect(page.locator("html")).not.toHaveAttribute("aria-busy", "true");
+  await expect(submitButton).toHaveClass(/btn-primary/);
+  await expect(submitButton).toHaveAttribute("aria-label", "Search");
+  await expect(submitButton.locator(".fa-caret-right")).toBeVisible();
+  await expect(queryInput).toHaveValue("debug:g foobar");
+  await expect(page).toHaveURL(/status=loading/);
+  await expect(page.locator("#alert")).toContainText("Shortcuts were still loading when you submitted.");
+
+  await queryInput.press("Enter");
+  await expect(page.locator("#target-domain")).toContainText("https://www.google");
+});
+
+test("Homepage should load a stored GitHub config without a second navigation", async ({ page }) => {
+  let navigationRequests = 0;
+  let configRequests = 0;
+  await page.addInitScript(() => {
+    localStorage.setItem("github", "testuser");
+  });
+  await page.route("https://raw.githubusercontent.com/testuser/trovu-data-user/master/config.yml", async (route) => {
+    configRequests += 1;
+    await route.fulfill({
+      body: "defaultKeyword: g",
+      contentType: "text/yaml",
+      status: 200,
+    });
+  });
+  page.on("request", (request) => {
+    if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
+      navigationRequests += 1;
+    }
+  });
+
+  await openLoadedHomepage(page);
+  await page.waitForTimeout(100);
+  expect(configRequests).toBe(1);
+  expect(navigationRequests).toBe(1);
+  await expect(page).toHaveURL(/github=testuser/);
+  await expect(page.locator('head link[rel="search"]')).toHaveAttribute("href", "/opensearch/?github=testuser");
+});
+
 test.describe("Homepage from default load", () => {
   test.beforeEach(async ({ page }) => {
     await openLoadedHomepage(page);

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -56,6 +56,8 @@ test("Homepage should expose a loading state and reject an early submit", async 
   try {
     await expect(page.locator("html")).toHaveAttribute("aria-busy", "true");
     await expect(queryInput).toBeFocused();
+    await expect(page.locator(".tagline")).toBeVisible();
+    await expect(page.locator(".examples")).toBeVisible();
     await expect(submitButton).toHaveClass(/btn-secondary/);
     await expect(submitButton).toHaveAttribute("aria-label", "Shortcuts are loading");
     await expect(submitButton).toHaveText("⏳");

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -254,7 +254,10 @@ test.describe("Homepage status states", () => {
   });
 
   test("should prefill the alternative query for deprecated shortcuts", async ({ page }) => {
-    await openLoadedHomepage(page, "#country=gb&language=en&query=oldshortcut&status=deprecated&alternative=g%20berlin");
+    await openLoadedHomepage(
+      page,
+      "#country=gb&language=en&query=oldshortcut&status=deprecated&alternative=g%20berlin",
+    );
     await expect(page.locator("#query")).toHaveValue("g berlin");
     await expect(page.locator("#alert")).toContainText("deprecated");
     await expect(page.locator("#alert em.query")).toHaveText("oldshortcut");

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -5,6 +5,37 @@ async function openLoadedHomepage(page, hash = "") {
   await expect(page.locator('[data-page-loaded="true"]')).toBeVisible();
 }
 
+test("Homepage startup should not wait for images", async ({ page }) => {
+  let resumeLogo;
+  await page.route("**/img/logo.png", async (route) => {
+    await new Promise((resolve) => {
+      resumeLogo = resolve;
+    });
+    await route.continue();
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  try {
+    await expect(page.locator('[data-page-loaded="true"]')).toBeVisible();
+  } finally {
+    resumeLogo?.();
+  }
+  await page.waitForLoadState("load");
+});
+
+test("Homepage startup should not reload after normalizing the hash", async ({ page }) => {
+  let navigationRequests = 0;
+  page.on("request", (request) => {
+    if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
+      navigationRequests += 1;
+    }
+  });
+
+  await openLoadedHomepage(page);
+  await page.waitForTimeout(100);
+  expect(navigationRequests).toBe(1);
+});
+
 test.describe("Homepage from default load", () => {
   test.beforeEach(async ({ page }) => {
     await openLoadedHomepage(page);
@@ -28,6 +59,13 @@ test.describe("Homepage from default load", () => {
 
     test("should have focus on input", async ({ page }) => {
       await expect(page.locator("#query")).toBeFocused();
+    });
+
+    test("should render icons from the stylesheet", async ({ page }) => {
+      const content = await page.locator(".fa-caret-right").evaluate((element) => {
+        return getComputedStyle(element, "::before").content;
+      });
+      expect(content).not.toMatch(/^(none|normal)$/);
     });
   });
 

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -78,7 +78,6 @@ test("Homepage should expose a loading state and reject an early submit", async 
     await expect(submitButton).toHaveClass(/btn-loading/);
     await expect(submitButton).toHaveAttribute("aria-label", "Shortcuts are loading");
     await expect(submitButton).toHaveText("⏳");
-    await expect(submitButton).toHaveCSS("background-color", "rgb(192, 192, 192)");
 
     await queryInput.fill("debug:g foobar");
     await queryInput.press("Enter");


### PR DESCRIPTION
## Summary

Improve homepage startup performance and make the loading state visible and actionable.

## Changes

- initialize the homepage immediately instead of waiting for `window.onload`
- remove redundant Font Awesome JavaScript and keep stylesheet-based icons
- normalize the hash with `history.replaceState()` to avoid an unnecessary reload
- show the input, slogan and examples immediately
- define the initial loading state directly in HTML:
  - `aria-busy="true"`
  - grey submit button with `⏳`
  - accessible loading label
- replace the hourglass with the blue caret button after shortcuts are ready
- preserve text entered while data is loading
- show `status=loading` when submitting too early and require an explicit second submit
- load `data.json` and optional GitHub config in parallel
- apply a GitHub username from `localStorage` during the first initialization
- add a 5-second timeout and fallback for optional remote config and namespace files
- temporarily deploy pushes from `codex/homepage-startup` for preview testing

## Testing

- `npm run lint-js`
- `npm run lint-yaml`
- `npm run validate-data`
- `npm run test-unit`
- `npm run test-calls`
- `npm run test-fe`
- `npx tsc --noEmit --pretty false`
- `git diff --check`

Added coverage for startup without JavaScript, delayed data loading, early submit behavior, stored GitHub config, remote timeouts and network failures.