### PR TITLE
fix: open target URLs in default browser when running standalone PWA

### DIFF
--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -377,7 +377,11 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    if (this.env.isRunningStandalone()) {
+      window.open(redirectUrl, '_blank');
+    } else {
+      window.location.href = redirectUrl;
+    }
   };
 
   showLoadingSubmitStatus() {


### PR DESCRIPTION
Fixes #329.

When Trovu is run as an installed Progressive Web App (PWA) in standalone mode, redirecting search targets via window.location.href opens them within the PWA container itself, which traps the user.

This PR checks if Trovu is running in standalone mode using 	his.env.isRunningStandalone() and, if so, opens external redirect URLs via window.open(redirectUrl, '_blank'). This directs the OS to open the target search link in the user's default system browser.

/claim #329