### PR TITLE
Speed up process redirect startup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - codex/process-startup
   pull_request:
     branches:
       - master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - codex/process-startup
   pull_request:
     branches:
       - master

--- a/src/html/process.html
+++ b/src/html/process.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Set no referrer, to enable duckduckgo feeling lucky. -->
     <meta name="referrer" content="no-referrer" />
+    <script type="module" src="../{{fileNameJs}}?{{currentTimestamp}}"></script>
     <style>
       #process {
         display: flex;
@@ -73,12 +74,11 @@
 
   <body>
     <div id="process">
-      <img id="process-icon" src="/img/icon.svg" alt="" width="16" height="16" />
+      <img id="process-icon" src="/img/icon.svg" alt="" width="16" height="16" decoding="async" fetchpriority="low" />
       <div id="process-text">
         <pre id="loading">Loading <span id="target-domain"></span></pre>
         <pre hidden id="log"></pre>
       </div>
     </div>
-    <script type="module" src="../{{fileNameJs}}?{{currentTimestamp}}"></script>
   </body>
 </html>

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -500,8 +500,11 @@ export default class Env {
       case "web-ext":
         prefix = "/";
         url = `${prefix}data.json?version=${this.gitInfo.commit.hash}`;
-        Env.fetchLog(this.context, prefix);
-        text = await Helper.fetchAsync(url, this);
+        {
+          const dataPromise = Helper.fetchAsync(url, this);
+          Env.fetchLog(this.context, prefix);
+          text = await dataPromise;
+        }
         break;
       case "raycast":
         prefix = "https://trovu.net/";

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -491,45 +491,51 @@ export default class Env {
    * @returns {Object} An object containing the fetched data.
    */
   async getData(): Promise<TrovuData | false> {
-    let text;
-    let url;
-    let prefix;
+    const loadFromUrl = async (url: string, prefix: string) => {
+      const dataPromise = Helper.fetchAsync(url, this);
+      Env.fetchLog(this.context, prefix);
+      return {
+        text: await dataPromise,
+        url,
+      };
+    };
+
+    let dataSource: { text: string | false | null; url: string };
     switch (this.context) {
       case "index":
       case "process":
       case "web-ext": {
-        prefix = "/";
-        url = `${prefix}data.json?version=${this.gitInfo.commit.hash}`;
-        const dataPromise = Helper.fetchAsync(url, this);
-        Env.fetchLog(this.context, prefix);
-        text = await dataPromise;
+        const prefix = "/";
+        dataSource = await loadFromUrl(`${prefix}data.json?version=${this.gitInfo.commit.hash}`, prefix);
         break;
       }
       case "raycast": {
-        prefix = "https://trovu.net/";
-        url = `${prefix}data.json`;
-        const dataPromise = Helper.fetchAsync(url, this);
-        Env.fetchLog(this.context, prefix);
-        text = await dataPromise;
+        const prefix = "https://trovu.net/";
+        dataSource = await loadFromUrl(`${prefix}data.json`, prefix);
         break;
       }
       case "node": {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const fs = require("fs");
-        url = "./dist/public/data.json";
-        text = fs.readFileSync(url, "utf8");
+        const url = "./dist/public/data.json";
+        dataSource = {
+          text: fs.readFileSync(url, "utf8"),
+          url,
+        };
         break;
       }
+      default:
+        return false;
     }
-    if (!text) {
+    if (!dataSource.text) {
       return false;
     }
     try {
-      const data = JSON.parse(text) as TrovuData;
+      const data = JSON.parse(dataSource.text) as TrovuData;
       return data;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Error parsing JSON in ${url}: ${message}`);
+      this.logger.error(`Error parsing JSON in ${dataSource.url}: ${message}`);
       return false;
     }
   }

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -497,21 +497,22 @@ export default class Env {
     switch (this.context) {
       case "index":
       case "process":
-      case "web-ext":
+      case "web-ext": {
         prefix = "/";
         url = `${prefix}data.json?version=${this.gitInfo.commit.hash}`;
-        {
-          const dataPromise = Helper.fetchAsync(url, this);
-          Env.fetchLog(this.context, prefix);
-          text = await dataPromise;
-        }
+        const dataPromise = Helper.fetchAsync(url, this);
+        Env.fetchLog(this.context, prefix);
+        text = await dataPromise;
         break;
-      case "raycast":
+      }
+      case "raycast": {
         prefix = "https://trovu.net/";
         url = `${prefix}data.json`;
+        const dataPromise = Helper.fetchAsync(url, this);
         Env.fetchLog(this.context, prefix);
-        text = await Helper.fetchAsync(url, this);
+        text = await dataPromise;
         break;
+      }
       case "node": {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const fs = require("fs");

--- a/src/ts/process.ts
+++ b/src/ts/process.ts
@@ -1,3 +1,3 @@
 import CallHandler from "./modules/CallHandler";
 
-document.querySelector("body").onload = () => CallHandler.handleCall();
+void CallHandler.handleCall();

--- a/tests/playwright/process.spec.js
+++ b/tests/playwright/process.spec.js
@@ -1,0 +1,23 @@
+const { test, expect } = require("@playwright/test");
+
+test("Process startup should not wait for images", async ({ page }) => {
+  let resumeIcon;
+  await page.route("**/img/icon.svg", async (route) => {
+    await new Promise((resolve) => {
+      resumeIcon = resolve;
+    });
+    await route.continue();
+  });
+
+  await page.goto("/process/index.html?#country=gb&debug=1&language=en&query=g%20foo", {
+    waitUntil: "domcontentloaded",
+  });
+
+  try {
+    await expect(page.locator("#target-domain")).toContainText("https://www.google");
+  } finally {
+    resumeIcon?.();
+  }
+
+  await page.waitForLoadState("load");
+});


### PR DESCRIPTION
## Summary

Optimize the `process/` redirect page startup so shortcut resolution no longer waits for non-critical page resources.

## Changes

- start `CallHandler.handleCall()` directly instead of waiting for `body.onload`
- move the process module script into the document head so the browser discovers it earlier
- mark the process icon as non-critical with async decoding and low fetch priority
- start the critical `data.json` fetch before the tracking `log.json` request
- refactor `Env.getData()` so URL-based contexts share the same data-first loading path
- add Playwright coverage proving `process/` resolves while the icon request is still blocked

## Testing

- `npm run lint-js`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npx playwright test tests/playwright/process.spec.js`
- `npm run test-unit`
- `npm run test-calls`
- `npm run validate-data`
- `npm run lint-yaml`
- `npm run test-fe` (`24 passed`)