### PR TITLE
Harden runtime resolver edge cases

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -1,6 +1,7 @@
 import CallHandler from "./CallHandler";
 import Env from "./Env";
 import ShortcutFinder from "./ShortcutFinder";
+import { createLogger } from "../../../tests/createLogger";
 import type { Shortcut } from "../types";
 
 describe("CallHandler", () => {
@@ -60,13 +61,7 @@ describe("CallHandler", () => {
       args: [],
       language: "en",
       country: "us",
-      logger: {
-        info: jest.fn(),
-        warning: jest.fn(),
-        error: jest.fn((message: string): never => {
-          throw new Error(message);
-        }),
-      },
+      logger: createLogger(),
     };
 
     expect(CallHandler.getRedirectResponse(env)).toMatchObject({

--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -1,6 +1,7 @@
 import CallHandler from "./CallHandler";
 import Env from "./Env";
 import ShortcutFinder from "./ShortcutFinder";
+import type { Shortcut } from "../types";
 
 describe("CallHandler", () => {
   test("getAlternative", async () => {
@@ -53,13 +54,19 @@ describe("CallHandler", () => {
     const shortcutSpy = jest.spyOn(ShortcutFinder, "findShortcut").mockReturnValue({
       url: "javascript:alert(1)",
       reachable: true,
-    } as AnyObject);
+    } as Shortcut);
     const env = {
       query: "evil",
       args: [],
       language: "en",
       country: "us",
-      logger: { info: jest.fn(), warning: jest.fn(), error: jest.fn() },
+      logger: {
+        info: jest.fn(),
+        warning: jest.fn(),
+        error: jest.fn((message: string): never => {
+          throw new Error(message);
+        }),
+      },
     };
 
     expect(CallHandler.getRedirectResponse(env)).toMatchObject({

--- a/src/ts/modules/Env.test.ts
+++ b/src/ts/modules/Env.test.ts
@@ -259,6 +259,25 @@ describe("Env", () => {
       expect(env.query).toBe("g foo");
     });
 
+    test("resets arguments to the full query when an extra namespace is invalid", async () => {
+      const response = {
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify(minimalData)),
+      };
+      const fetchMock = jest.fn().mockResolvedValue(response as unknown as Response);
+      global.fetch = fetchMock as typeof fetch;
+      jest.spyOn(Env, "fetchLog").mockImplementation(() => {});
+      jest.spyOn(NamespaceFetcher.prototype, "getNamespaceInfos").mockResolvedValue({});
+
+      const env = new Env({ context: "process" });
+      await env.populate({ query: "foo.de test" });
+
+      expect(env.extraNamespaceName).toBeUndefined();
+      expect(env.keyword).toBe("");
+      expect(env.argumentString).toBe("foo.de test");
+      expect(env.args).toEqual(["foo.de test"]);
+    });
+
     test("loads a stored GitHub config in parallel with the initial data fetch", async () => {
       let resolveData: (response: Response) => void;
       const dataResponse = {

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -223,7 +223,8 @@ export default class Env {
     if (this.extraNamespaceName && !this.isValidNamespace(this.extraNamespaceName)) {
       delete this.extraNamespaceName;
       this.keyword = "";
-      this.arguments = [this.query];
+      this.argumentString = this.query;
+      this.args = [this.query];
     }
   }
 

--- a/src/ts/modules/Logger.ts
+++ b/src/ts/modules/Logger.ts
@@ -62,7 +62,7 @@ export default class Logger {
   success(message: string) {
     this.log("success", message);
   }
-  error(message: string) {
+  error(message: string): never {
     this.log("error", message);
     this.showLog();
     throw new Error(message);

--- a/src/ts/modules/NamespaceFetcher.test.ts
+++ b/src/ts/modules/NamespaceFetcher.test.ts
@@ -1,20 +1,10 @@
 import Env from "./Env";
 import NamespaceFetcher from "./NamespaceFetcher";
+import { createLogger } from "../../../tests/createLogger";
 import jsyaml from "js-yaml";
 
 function cloneObject(obj) {
   return JSON.parse(JSON.stringify(obj));
-}
-
-function createLogger() {
-  return {
-    error: jest.fn((message) => {
-      throw new Error(message);
-    }),
-    info: jest.fn(),
-    success: jest.fn(),
-    warning: jest.fn(),
-  };
 }
 
 describe("NamespaceFetcher.getInitialNamespaceInfo", () => {

--- a/src/ts/modules/NamespaceFetcher.test.ts
+++ b/src/ts/modules/NamespaceFetcher.test.ts
@@ -6,6 +6,15 @@ function cloneObject(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
+function createLogger() {
+  return {
+    error: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+  };
+}
+
 describe("NamespaceFetcher.getInitialNamespaceInfo", () => {
   test("site", () => {
     const env = new Env();
@@ -40,8 +49,11 @@ describe("NamespaceFetcher.getInitialNamespaceInfo", () => {
     });
   });
   test("configUrl, this user (negative)", () => {
-    const env = new Env();
-    expect(new NamespaceFetcher(env).getInitialNamespaceInfo({ github: "." })).toEqual(false);
+    const logger = createLogger();
+    expect(new NamespaceFetcher({ logger }).getInitialNamespaceInfo({ github: "." })).toEqual(false);
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Invalid namespace: {"github":"."} provided without a github repository name.',
+    );
   });
   test("name and url", () => {
     const env = new Env();
@@ -76,20 +88,24 @@ describe("NamespaceFetcher.getInitialNamespaceInfo", () => {
     });
   });
   test("only url (negative)", () => {
-    const env = new Env();
+    const logger = createLogger();
     expect(
-      new NamespaceFetcher(env).getInitialNamespaceInfo({
+      new NamespaceFetcher({ logger }).getInitialNamespaceInfo({
         url: "https://johndoe.com/trovu-data-user/",
       }),
     ).toEqual(false);
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Invalid namespace: {"url":"https://johndoe.com/trovu-data-user/"} provided without a name.',
+    );
   });
   test("only shortcuts (negative)", () => {
-    const env = new Env();
+    const logger = createLogger();
     expect(
-      new NamespaceFetcher(env).getInitialNamespaceInfo({
+      new NamespaceFetcher({ logger }).getInitialNamespaceInfo({
         shortcuts: {},
       }),
     ).toEqual(false);
+    expect(logger.warning).toHaveBeenCalledWith('Invalid namespace: {"shortcuts":{}} provided without a name.');
   });
   test("name and shortcuts, short notation", () => {
     const env = new Env();
@@ -174,12 +190,7 @@ describe("NamespaceFetcher.addNamespaceInfo", () => {
 
 describe("NamespaceFetcher.fetchNamespaceInfos", () => {
   test("continues with an empty namespace after a network error", async () => {
-    const logger = {
-      error: jest.fn(),
-      info: jest.fn(),
-      success: jest.fn(),
-      warning: jest.fn(),
-    };
+    const logger = createLogger();
     const originalFetch = global.fetch;
     global.fetch = jest.fn().mockRejectedValue(new Error("offline"));
     const fetcher = new NamespaceFetcher({ logger });
@@ -204,7 +215,8 @@ describe("NamespaceFetcher.fetchNamespaceInfos", () => {
   });
 
   test("with endless new user namespaces (negative)", async () => {
-    const fetcher = new NamespaceFetcher(new Env({}));
+    const logger = createLogger();
+    const fetcher = new NamespaceFetcher({ logger });
     const namespaceInfos = {
       loop0: {
         name: "loop0",
@@ -235,6 +247,7 @@ describe("NamespaceFetcher.fetchNamespaceInfos", () => {
     await expect(fetcher.fetchNamespaceInfos(namespaceInfos)).rejects.toThrow(
       "fetchNamespaceInfos: Loop ran already 10 times.",
     );
+    expect(logger.error).toHaveBeenCalledWith("fetchNamespaceInfos: Loop ran already 10 times.");
   });
 });
 
@@ -288,6 +301,7 @@ describe("NamespaceFetcher.processInclude", () => {
   });
 
   test("with loop (negative)", () => {
+    const logger = createLogger();
     const namespaceInfosLoop = jsyaml.load(`
       leo:
         shortcuts:
@@ -306,11 +320,13 @@ describe("NamespaceFetcher.processInclude", () => {
       key: tic 1
     `);
     expect(() => {
-      new NamespaceFetcher(new Env({})).processInclude(shortcut, "leo", namespaceInfosLoop);
+      new NamespaceFetcher({ logger }).processInclude(shortcut, "leo", namespaceInfosLoop);
     }).toThrow(Error);
+    expect(logger.error).toHaveBeenCalledWith("processInclude: Loop ran already 10 times.");
   });
 
   test("faulty (negative)", () => {
+    const logger = createLogger();
     const namespaceInfos = jsyaml.load(`
       leo:
         shortcuts:
@@ -321,11 +337,13 @@ describe("NamespaceFetcher.processInclude", () => {
     include: tic 1
     `);
     expect(() => {
-      new NamespaceFetcher(new Env({})).processInclude(shortcut, "leo", namespaceInfos);
+      new NamespaceFetcher({ logger }).processInclude(shortcut, "leo", namespaceInfos);
     }).toThrow(Error);
+    expect(logger.error).toHaveBeenCalledWith('Include with missing key at: "tic 1"');
   });
 
   test("multiple", () => {
+    const logger = createLogger();
     const namespaceInfosMultiple = jsyaml.load(`
       leo:
         shortcuts:
@@ -348,11 +366,12 @@ describe("NamespaceFetcher.processInclude", () => {
       namespace: leo
     `);
     expect(
-      new NamespaceFetcher(new Env({ language: "de" })).processInclude(shortcut, "o", namespaceInfosMultiple),
+      new NamespaceFetcher({ language: "de", logger }).processInclude(shortcut, "o", namespaceInfosMultiple),
     ).toMatchObject({
       title: "Französisch-Deutsch (leo.org)",
       url: "https://dict.leo.org/französisch-deutsch/{%word}",
     });
+    expect(logger.warning).toHaveBeenCalledWith('Namespace "lge" does not exist or has no shortcuts.');
   });
 });
 

--- a/src/ts/modules/NamespaceFetcher.test.ts
+++ b/src/ts/modules/NamespaceFetcher.test.ts
@@ -8,7 +8,9 @@ function cloneObject(obj) {
 
 function createLogger() {
   return {
-    error: jest.fn(),
+    error: jest.fn((message) => {
+      throw new Error(message);
+    }),
     info: jest.fn(),
     success: jest.fn(),
     warning: jest.fn(),

--- a/src/ts/modules/NamespaceFetcher.ts
+++ b/src/ts/modules/NamespaceFetcher.ts
@@ -30,11 +30,6 @@ export default class NamespaceFetcher {
     this.namespaceInfos = {};
   }
 
-  logAndThrow(message: string): never {
-    this.env.logger.error(message);
-    throw new Error(message);
-  }
-
   /**
    * Gets namespace information for given namespaces
    * @param {Array} namespaces - An array of namespace names
@@ -191,7 +186,7 @@ export default class NamespaceFetcher {
     do {
       i++;
       if (i >= 10) {
-        this.logAndThrow(`fetchNamespaceInfos: Loop ran already ${i} times.`);
+        this.env.logger.error(`fetchNamespaceInfos: Loop ran already ${i} times.`);
       }
       // Get user namespaces without shortcuts.
       newNamespaceInfos = Object.values(namespaceInfos).filter((item) => item.type === "user" && !item.shortcuts);
@@ -400,12 +395,13 @@ export default class NamespaceFetcher {
    */
   processInclude(shortcut: Shortcut, namespaceName: string, namespaceInfos: NamespaceMap, depth = 0): Shortcut | false {
     if (depth >= 10) {
-      this.logAndThrow(`processInclude: Loop ran already ${depth} times.`);
+      this.env.logger.error(`processInclude: Loop ran already ${depth} times.`);
     }
     const includes = this.getIncludes(shortcut);
     for (const include of includes) {
       if (!include.key) {
-        this.logAndThrow(`Include with missing key at: ${JSON.stringify(include)}`);
+        this.env.logger.error(`Include with missing key at: ${JSON.stringify(include)}`);
+        continue;
       }
       const keyUnprocessed = include.key;
       const key = UrlProcessor.replaceVariables(keyUnprocessed, {

--- a/src/ts/modules/NamespaceFetcher.ts
+++ b/src/ts/modules/NamespaceFetcher.ts
@@ -401,7 +401,6 @@ export default class NamespaceFetcher {
     for (const include of includes) {
       if (!include.key) {
         this.env.logger.error(`Include with missing key at: ${JSON.stringify(include)}`);
-        continue;
       }
       const keyUnprocessed = include.key;
       const key = UrlProcessor.replaceVariables(keyUnprocessed, {

--- a/src/ts/modules/NamespaceFetcher.ts
+++ b/src/ts/modules/NamespaceFetcher.ts
@@ -30,6 +30,11 @@ export default class NamespaceFetcher {
     this.namespaceInfos = {};
   }
 
+  logAndThrow(message: string): never {
+    this.env.logger.error(message);
+    throw new Error(message);
+  }
+
   /**
    * Gets namespace information for given namespaces
    * @param {Array} namespaces - An array of namespace names
@@ -186,7 +191,7 @@ export default class NamespaceFetcher {
     do {
       i++;
       if (i >= 10) {
-        this.env.logger.error(`fetchNamespaceInfos: Loop ran already ${i} times.`);
+        this.logAndThrow(`fetchNamespaceInfos: Loop ran already ${i} times.`);
       }
       // Get user namespaces without shortcuts.
       newNamespaceInfos = Object.values(namespaceInfos).filter((item) => item.type === "user" && !item.shortcuts);
@@ -395,12 +400,12 @@ export default class NamespaceFetcher {
    */
   processInclude(shortcut: Shortcut, namespaceName: string, namespaceInfos: NamespaceMap, depth = 0): Shortcut | false {
     if (depth >= 10) {
-      this.env.logger.error(`processInclude: Loop ran already ${depth} times.`);
+      this.logAndThrow(`processInclude: Loop ran already ${depth} times.`);
     }
     const includes = this.getIncludes(shortcut);
     for (const include of includes) {
       if (!include.key) {
-        this.env.logger.error(`Include with missing key at: ${JSON.stringify(include)}`);
+        this.logAndThrow(`Include with missing key at: ${JSON.stringify(include)}`);
       }
       const keyUnprocessed = include.key;
       const key = UrlProcessor.replaceVariables(keyUnprocessed, {

--- a/src/ts/modules/ShortcutFinder.test.ts
+++ b/src/ts/modules/ShortcutFinder.test.ts
@@ -1,14 +1,5 @@
 import ShortcutFinder from "./ShortcutFinder";
-
-function createLogger() {
-  return {
-    error: jest.fn((message: string): never => {
-      throw new Error(message);
-    }),
-    info: jest.fn(),
-    warning: jest.fn(),
-  };
-}
+import { createLogger } from "../../../tests/createLogger";
 
 describe("ShortcutFinder.matchShortcuts", () => {
   test("returns the first reachable shortcut for the requested keyword and argument count", () => {

--- a/src/ts/modules/ShortcutFinder.test.ts
+++ b/src/ts/modules/ShortcutFinder.test.ts
@@ -1,5 +1,15 @@
 import ShortcutFinder from "./ShortcutFinder";
 
+function createLogger() {
+  return {
+    error: jest.fn((message: string): never => {
+      throw new Error(message);
+    }),
+    info: jest.fn(),
+    warning: jest.fn(),
+  };
+}
+
 describe("ShortcutFinder.matchShortcuts", () => {
   test("returns the first reachable shortcut for the requested keyword and argument count", () => {
     const shortcut = { reachable: true, url: "https://example.com" };
@@ -24,7 +34,7 @@ describe("ShortcutFinder.matchShortcuts", () => {
 
 describe("ShortcutFinder.findShortcut", () => {
   test("falls back to the whole argument string when comma-splitting misses a shortcut", () => {
-    const logger = { info: jest.fn(), warning: jest.fn(), error: jest.fn() };
+    const logger = createLogger();
     const shortcut = { reachable: true, url: "https://example.com" };
     const env = {
       keyword: "gm",
@@ -50,7 +60,7 @@ describe("ShortcutFinder.findShortcut", () => {
   });
 
   test("falls back to the default keyword using the full query", () => {
-    const logger = { info: jest.fn(), warning: jest.fn(), error: jest.fn() };
+    const logger = createLogger();
     const shortcut = { reachable: true, url: "https://example.com" };
     const defaultKeyword = "w";
     const env = {
@@ -77,7 +87,7 @@ describe("ShortcutFinder.findShortcut", () => {
   });
 
   test("finally returns a non-reachable shortcut so the caller can inform the user", () => {
-    const logger = { info: jest.fn(), warning: jest.fn(), error: jest.fn() };
+    const logger = createLogger();
     const shortcut = { reachable: false, url: "https://example.com" };
     const env = {
       keyword: "gm",

--- a/src/ts/modules/UrlProcessor.test.ts
+++ b/src/ts/modules/UrlProcessor.test.ts
@@ -146,4 +146,26 @@ describe("UrlProcessor", () => {
       expect(UrlProcessor.processAttributeEncoding({ encoding: "none" }, "ÄÖÜäöü")).toEqual("ÄÖÜäöü");
     });
   });
+
+  describe("processTypeTime", () => {
+    test("formats a valid time", () => {
+      expect(UrlProcessor.processTypeTime("8:15", { output: "HH-mm" })).toBe("08-15");
+    });
+
+    test("keeps an invalid time unchanged", () => {
+      expect(UrlProcessor.processTypeTime("soon", {})).toBe("soon");
+    });
+  });
+
+  describe("replaceArguments", () => {
+    test("processes time placeholders before encoding", () => {
+      expect(
+        UrlProcessor.replaceArguments("https://example.com/?time=<time: {type: time, output: HH-mm}>", ["8:15"], {
+          country: "de",
+          data: {},
+          language: "de",
+        }),
+      ).toBe("https://example.com/?time=08-15");
+    });
+  });
 });

--- a/src/ts/modules/UrlProcessor.ts
+++ b/src/ts/modules/UrlProcessor.ts
@@ -197,10 +197,10 @@ export default class UrlProcessor {
 
   static processTypeTime(processedArgument: string, attributes: PlaceholderAttributes): string {
     const timeNative = TimeType.parse(processedArgument);
-    const time = dayjs(timeNative);
     // If time could be parsed:
     // Set argument.
-    if (time) {
+    if (timeNative) {
+      const time = dayjs(timeNative);
       let format = "HH:mm";
       if (attributes.output) {
         format = attributes.output;

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -15,7 +15,7 @@ export interface LoggerLike {
   info(message: string): void;
   warning(message: string): void;
   success?(message: string): void;
-  error(message: string): never | void;
+  error(message: string): never;
 }
 
 export interface PlaceholderAttributes {

--- a/tests/createLogger.ts
+++ b/tests/createLogger.ts
@@ -1,0 +1,17 @@
+import type { LoggerLike } from "../src/ts/types";
+
+export function createLogger(): LoggerLike & {
+  error: jest.Mock<never, [string]>;
+  info: jest.Mock<void, [string]>;
+  success: jest.Mock<void, [string]>;
+  warning: jest.Mock<void, [string]>;
+} {
+  return {
+    error: jest.fn((message: string): never => {
+      throw new Error(message);
+    }),
+    info: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+  };
+}


### PR DESCRIPTION
## Summary

- keep invalid `type: time` arguments unchanged instead of resolving them to the current time
- reset `args` and `argumentString` correctly when an invalid extra namespace is discarded
- align `NamespaceFetcher` negative tests with the existing `Logger.error()` throw behavior
- add focused regression tests for time placeholders, invalid extra namespaces, and namespace/include failure paths

## Validation

- `npm run typecheck`
- `npm run lint-js`
- `npm run build`
- `npm run test-unit`
- `npm run test-calls`
- `npm run test-fe`

## Notes

No dependency updates, no `tsconfig` strictness changes, and no public shortcut/URL API changes.