### PR TITLE
Show submit progress on homepage

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -82,6 +82,58 @@ main .jumbotron {
 }
 
 #query-form {
+  .input-group {
+    border-radius: 0.5rem;
+    overflow: visible;
+    position: relative;
+
+    > * {
+      position: relative;
+      z-index: 1;
+    }
+  }
+
+  &.is-submitting {
+    .input-group {
+      box-shadow:
+        0 0 0 0.18rem rgba(13, 110, 253, 0.18),
+        0 0 1.1rem rgba(13, 202, 240, 0.35);
+
+      &::before {
+        animation:
+          query-submit-shimmer 1.5s linear infinite,
+          query-submit-pulse 1.8s ease-in-out infinite;
+        background: linear-gradient(120deg, var(--bs-primary), var(--bs-info), #fff, var(--bs-primary));
+        background-size: 240% 240%;
+        border-radius: 0.6rem;
+        bottom: -2px;
+        content: "";
+        left: -2px;
+        pointer-events: none;
+        position: absolute;
+        right: -2px;
+        top: -2px;
+        z-index: 0;
+      }
+    }
+
+    #query,
+    button[type="submit"] {
+      box-shadow: none;
+    }
+
+    button[type="submit"] {
+      cursor: progress;
+    }
+  }
+
+  &:not(.is-submitting) {
+    .input-group::before {
+      content: "";
+      display: none;
+    }
+  }
+
   button[type="submit"] {
     font-size: 1.4em;
     min-width: 2em;
@@ -91,6 +143,38 @@ main .jumbotron {
     }
   }
 }
+
+@keyframes query-submit-shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 240% 50%;
+  }
+}
+
+@keyframes query-submit-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 0.95;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #query-form.is-submitting .input-group {
+    box-shadow: 0 0 0 0.18rem rgba(13, 110, 253, 0.32);
+
+    &::before {
+      animation: none;
+      background: var(--bs-primary);
+      opacity: 0.45;
+    }
+  }
+}
+
 #query {
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -17,6 +17,7 @@ import countriesList from "countries-list";
 export default class Home {
   env!: Env;
   queryInput!: HTMLInputElement;
+  queryForm!: HTMLFormElement;
   suggestions!: Suggestions;
   submitButton!: HTMLButtonElement;
   initialized = false;
@@ -82,14 +83,17 @@ export default class Home {
       },
       false,
     );
-    window.addEventListener("pageshow", (event) => {
-      if (event.persisted) {
-        // If true, the page was loaded from cache
-        const queryElement = document.getElementById("query") as HTMLInputElement | null;
-        queryElement?.focus();
-      }
-    });
+    window.addEventListener("pageshow", this.handlePageShow);
   }
+
+  handlePageShow = (event: PageTransitionEvent) => {
+    if (!event.persisted) {
+      return;
+    }
+    // If true, the page was loaded from cache.
+    this.hideSubmitProgress();
+    this.queryInput.focus();
+  };
 
   prepareLoadingUi(params: EnvParams) {
     const queryForm = document.getElementById("query-form") as HTMLFormElement | null;
@@ -97,6 +101,7 @@ export default class Home {
     if (!queryForm || !submitButton) {
       throw new Error('Missing element "#query-form" or its submit button.');
     }
+    this.queryForm = queryForm;
     this.submitButton = submitButton;
     queryForm.onsubmit = this.submitQuery;
     this.queryInput.addEventListener("input", () => {
@@ -112,6 +117,7 @@ export default class Home {
 
   showReadyState() {
     document.documentElement.removeAttribute("aria-busy");
+    this.hideSubmitProgress();
     this.submitButton.classList.remove("btn-loading");
     this.submitButton.classList.add("btn-primary");
     this.submitButton.setAttribute("aria-label", "Search");
@@ -352,13 +358,24 @@ export default class Home {
       return;
     }
 
+    if (this.queryForm.classList.contains("is-submitting")) {
+      return;
+    }
+
     // Must create new env instance here,
     // because extraNamespace might have changed reachability,
     // or asking for a not yet parsed Github namespace.
-    const envQuery = new Env({ context: "index" });
-    const params: EnvParams = Env.getParamsFromUrl();
-    params.query = this.queryInput.value;
-    await envQuery.populate(params);
+    this.showSubmitProgress();
+    let envQuery: Env;
+    try {
+      envQuery = new Env({ context: "index" });
+      const params: EnvParams = Env.getParamsFromUrl();
+      params.query = this.queryInput.value;
+      await envQuery.populate(params);
+    } catch (error) {
+      this.hideSubmitProgress();
+      throw error;
+    }
 
     const response: RedirectResponse = CallHandler.getRedirectResponse(envQuery);
 
@@ -379,6 +396,20 @@ export default class Home {
     }
     window.location.href = redirectUrl;
   };
+
+  showSubmitProgress() {
+    this.queryForm.classList.add("is-submitting");
+    this.queryForm.setAttribute("aria-busy", "true");
+    this.submitButton.disabled = true;
+    this.submitButton.setAttribute("aria-label", "Processing query");
+  }
+
+  hideSubmitProgress() {
+    this.queryForm.classList.remove("is-submitting");
+    this.queryForm.removeAttribute("aria-busy");
+    this.submitButton.disabled = false;
+    this.submitButton.setAttribute("aria-label", "Search");
+  }
 
   showLoadingSubmitStatus() {
     const params = Env.getUrlSearchParams();

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -130,6 +130,73 @@ test("Homepage should load a stored GitHub config without a second navigation", 
   await expect(page.locator('head link[rel="search"]')).toHaveAttribute("href", "/opensearch/?github=testuser");
 });
 
+test("Homepage should show submit progress while resolving a query", async ({ page }) => {
+  let configRequests = 0;
+  let resumeSubmitConfig;
+  await page.addInitScript(() => {
+    localStorage.setItem("github", "testuser");
+  });
+  await page.route("https://raw.githubusercontent.com/testuser/trovu-data-user/master/config.yml", async (route) => {
+    configRequests += 1;
+    if (configRequests === 2) {
+      await new Promise((resolve) => {
+        resumeSubmitConfig = resolve;
+      });
+    }
+    await route.fulfill({
+      body: "defaultKeyword: g",
+      contentType: "text/yaml",
+      status: 200,
+    });
+  });
+  await page.route("https://www.google.co.uk/**", async (route) => {
+    await route.fulfill({
+      body: "<!doctype html><title>Google</title>",
+      contentType: "text/html",
+      status: 200,
+    });
+  });
+
+  await openLoadedHomepage(page);
+  expect(configRequests).toBe(1);
+  const queryForm = page.locator("#query-form");
+  const queryInput = page.locator("#query");
+  const submitButton = page.locator('#query-form button[type="submit"]');
+
+  await queryInput.fill("g submit feedback");
+  await queryInput.press("Enter");
+
+  await expect(queryForm).toHaveClass(/is-submitting/);
+  await expect(queryForm).toHaveAttribute("aria-busy", "true");
+  await expect(submitButton).toBeDisabled();
+  await expect(submitButton).toHaveAttribute("aria-label", "Processing query");
+  await expect(queryInput).toBeFocused();
+  await expect(queryForm.locator(".input-group")).toHaveCSS("position", "relative");
+  const inputGroupStyles = await queryForm.locator(".input-group").evaluate((inputGroup) => {
+    const shimmer = getComputedStyle(inputGroup, "::before");
+    return {
+      boxShadow: getComputedStyle(inputGroup).boxShadow,
+      shimmerBackground: shimmer.backgroundImage,
+      shimmerContent: shimmer.content,
+      shimmerPosition: shimmer.position,
+    };
+  });
+  expect(inputGroupStyles.boxShadow).not.toBe("none");
+  expect(inputGroupStyles.shimmerContent).toBe('""');
+  expect(inputGroupStyles.shimmerPosition).toBe("absolute");
+  expect(inputGroupStyles.shimmerBackground).toContain("linear-gradient");
+
+  resumeSubmitConfig?.();
+  await page.waitForURL(/google\.co\.uk/);
+  await page.goBack();
+  await expect(page.locator('[data-page-loaded="true"]')).toBeVisible();
+  await expect(queryForm).not.toHaveClass(/is-submitting/);
+  await expect(queryForm).not.toHaveAttribute("aria-busy", "true");
+  await expect(submitButton).not.toBeDisabled();
+  await expect(submitButton).toHaveAttribute("aria-label", "Search");
+  await expect(queryInput).toBeFocused();
+});
+
 test.describe("Homepage from default load", () => {
   test.beforeEach(async ({ page }) => {
     await openLoadedHomepage(page);


### PR DESCRIPTION
## Summary

- add a shimmering/glow submit state around the homepage query input
- keep the submit feedback visible until the browser leaves the current page
- clear stale submit state when returning via browser back/forward cache
- add Playwright coverage for the pending submit UI and return cleanup

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run lint-js`
- `npx playwright test tests/playwright/home.spec.js -g "submit progress"`
- `npm run test-fe`