### PR TITLE
Use Android intents for standalone PWA redirects

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -71,4 +71,38 @@ describe("CallHandler", () => {
 
     shortcutSpy.mockRestore();
   });
+  test("getNavigationUrl keeps regular browser redirects unchanged", () => {
+    const androidSpy = jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+    const env = {
+      isRunningStandalone: () => false,
+    };
+
+    expect(CallHandler.getNavigationUrl("https://www.google.com/search?q=foo", env)).toBe(
+      "https://www.google.com/search?q=foo",
+    );
+
+    androidSpy.mockRestore();
+  });
+  test("getNavigationUrl uses Android intents for standalone PWA web redirects", () => {
+    const androidSpy = jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+    const env = {
+      isRunningStandalone: () => true,
+    };
+
+    expect(CallHandler.getNavigationUrl("https://www.google.com/search?q=foo", env)).toBe(
+      "intent://www.google.com/search?q=foo#Intent;scheme=https;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dfoo;end",
+    );
+
+    androidSpy.mockRestore();
+  });
+  test("getNavigationUrl does not use Android intents for mailto redirects", () => {
+    const androidSpy = jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+    const env = {
+      isRunningStandalone: () => true,
+    };
+
+    expect(CallHandler.getNavigationUrl("mailto:test@example.com", env)).toBe("mailto:test@example.com");
+
+    androidSpy.mockRestore();
+  });
 });

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    window.location.replace(this.getNavigationUrl(redirectUrl, env));
   }
 
   /**
@@ -130,6 +130,33 @@ export default class CallHandler {
       return false;
     }
     return ["http:", "https:", "mailto:"].includes(parsedUrl.protocol);
+  }
+
+  static getNavigationUrl(redirectUrl: string, env: Pick<Env, "isRunningStandalone">): string {
+    if (!this.shouldUseAndroidIntent(redirectUrl, env)) {
+      return redirectUrl;
+    }
+
+    const url = new URL(redirectUrl);
+    const path = `${url.host}${url.pathname}${url.search}${url.hash}`;
+    const scheme = url.protocol.replace(":", "");
+    return `intent://${path}#Intent;scheme=${scheme};S.browser_fallback_url=${encodeURIComponent(redirectUrl)};end`;
+  }
+
+  static shouldUseAndroidIntent(redirectUrl: string, env: Pick<Env, "isRunningStandalone">): boolean {
+    if (!env.isRunningStandalone() || !this.isAndroid()) {
+      return false;
+    }
+
+    try {
+      return ["http:", "https:"].includes(new URL(redirectUrl).protocol);
+    } catch {
+      return false;
+    }
+  }
+
+  static isAndroid(): boolean {
+    return /Android/i.test(window.navigator.userAgent);
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    window.location.href = CallHandler.getNavigationUrl(redirectUrl, envQuery);
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
## Summary
- route Android standalone PWA web redirects through intent:// URLs so target pages can open outside the PWA
- keep regular browser, non-Android, and mailto redirects unchanged
- apply the same navigation helper from both the home form flow and process page flow

## Verification
- npx.cmd jest src/ts/modules/CallHandler.test.ts --runInBand
- npm.cmd run typecheck
- npm.cmd run build-site

## Notes
Android device verification video for issue #329 will be added in a follow-up comment.