### PR TITLE
Fix redirect handling in standalone mode

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -5,6 +5,25 @@ import { createLogger } from "../../../tests/createLogger";
 import type { Shortcut } from "../types";
 
 describe("CallHandler", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+  let originalNavigatorStandalone: boolean | undefined;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    originalNavigatorStandalone = (window.navigator as Navigator & { standalone?: boolean }).standalone;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    Object.defineProperty(window.navigator, "standalone", {
+      configurable: true,
+      value: originalNavigatorStandalone,
+    });
+  });
+
   test("getAlternative", async () => {
     const shortcut = {
       deprecated: {
@@ -50,6 +69,40 @@ describe("CallHandler", () => {
   });
   test("isSafeRedirectUrl blocks unparseable URLs", () => {
     expect(CallHandler.isSafeRedirectUrl("not a url")).toBe(false);
+  });
+  test("isStandalonePwa returns true for standalone display mode", () => {
+    const matchMedia = jest.fn((query: string) => {
+      return {
+        matches: query === "(display-mode: standalone)",
+      };
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: matchMedia,
+    });
+    Object.defineProperty(window.navigator, "standalone", {
+      configurable: true,
+      value: false,
+    });
+
+    expect(CallHandler.isStandalonePwa()).toBe(true);
+  });
+  test("isStandalonePwa returns false for browser tabs", () => {
+    const matchMedia = jest.fn(() => {
+      return {
+        matches: false,
+      };
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: matchMedia,
+    });
+    Object.defineProperty(window.navigator, "standalone", {
+      configurable: true,
+      value: false,
+    });
+
+    expect(CallHandler.isStandalonePwa()).toBe(false);
   });
   test("getRedirectResponse returns suspicious for blocked redirect URLs", () => {
     const shortcutSpy = jest.spyOn(ShortcutFinder, "findShortcut").mockReturnValue({

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.navigateToRedirectUrl(redirectUrl);
   }
 
   /**
@@ -130,6 +130,24 @@ export default class CallHandler {
       return false;
     }
     return ["http:", "https:", "mailto:"].includes(parsedUrl.protocol);
+  }
+
+  static isStandalonePwa(): boolean {
+    const navigatorStandalone = (window.navigator as Navigator & { standalone?: boolean }).standalone;
+    return Boolean(
+      window.matchMedia?.("(display-mode: standalone)")?.matches ||
+        window.matchMedia?.("(display-mode: fullscreen)")?.matches ||
+        navigatorStandalone,
+    );
+  }
+
+  static navigateToRedirectUrl(redirectUrl: string): void {
+    if (this.isStandalonePwa()) {
+      window.open(redirectUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    window.location.replace(redirectUrl);
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.navigateToRedirectUrl(redirectUrl);
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
### What changed
- Route redirect handling through a standalone-aware navigation helper.
- Keep normal browser behavior unchanged while opening redirects externally in standalone/PWA mode.
- Share the same redirect behavior between the call handler and homepage submit flow.
- Add tests for standalone detection and restore browser globals between tests.

### Validation
- npm run build
- npm run typecheck
- npm run test-calls
- npm run test-unit