### PR TITLE
fix: open target URLs in default browser from PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,11 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    if (env.isRunningStandalone() && /^https?:\/\//.test(redirectUrl)) {
+      window.open(redirectUrl, "_blank");
+    } else {
+      window.location.replace(redirectUrl);
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,11 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    if (this.env.isRunningStandalone() && /^https?:\/\//.test(redirectUrl)) {
+      window.open(redirectUrl, "_blank");
+    } else {
+      window.location.href = redirectUrl;
+    }
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
## Summary

When using Trovu from its PWA (installed on Android/iOS), target URLs opened within the PWA instead of the default browser. This fix detects when the app is running in standalone/PWA mode and uses `window.open(url, '_blank')` instead of `window.location.href` to open external redirect URLs in the default browser.

## Changes

- **`src/ts/modules/Home.ts`**: When submitting a query from the homepage in PWA mode, external URLs now open via `window.open(url, '_blank')` instead of navigating within the PWA.
- **`src/ts/modules/CallHandler.ts`**: Same treatment for the `/process/` redirect path.

Both changes only apply when:
1. The app is running in standalone mode (`window.navigator.standalone` or `(display-mode: standalone)` media query matches)
2. The redirect URL is an external HTTP/HTTPS URL (relative URLs like the error fallback to the homepage still navigate normally)

## Testing

- TypeScript type check passes
- All 135 unit tests pass
- All 26 call tests pass