### PR TITLE
fix: open PWA target URLs in default browser (#329)

### DIFF
--- a/src/manifest/site.webmanifest
+++ b/src/manifest/site.webmanifest
@@ -42,6 +42,7 @@
     "background_color": "#ffffff",
     "start_url": "/index.html",
     "display": "standalone",
+    "handle_links": "not-preferred",
     "prefer_related_applications": false,
     "theme_color": "#343a40",
     "dir": "auto",

--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -71,4 +71,27 @@ describe("CallHandler", () => {
 
     shortcutSpy.mockRestore();
   });
+  test("shouldOpenInExternalBrowser is false in regular browser mode", () => {
+    const androidSpy = jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+    const env = { isRunningStandalone: () => false };
+
+    expect(CallHandler.shouldOpenInExternalBrowser("https://www.google.com/search?q=foo", env)).toBe(false);
+
+    androidSpy.mockRestore();
+  });
+  test("buildAndroidIntentUrl encodes external redirects for standalone PWA", () => {
+    expect(CallHandler.buildAndroidIntentUrl("https://www.google.com/search?q=foo")).toBe(
+      "intent://www.google.com/search?q=foo#Intent;scheme=https;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dfoo;end",
+    );
+  });
+  test("shouldOpenInExternalBrowser uses Android intents only for http(s) standalone redirects", () => {
+    const androidSpy = jest.spyOn(CallHandler, "isAndroid").mockReturnValue(true);
+    const env = { isRunningStandalone: () => true };
+
+    expect(CallHandler.shouldOpenInExternalBrowser("https://www.google.com/search?q=foo", env)).toBe(true);
+    expect(CallHandler.shouldOpenInExternalBrowser("mailto:test@example.com", env)).toBe(false);
+    expect(CallHandler.shouldOpenInExternalBrowser("../index.html#status=not_found", env)).toBe(false);
+
+    androidSpy.mockRestore();
+  });
 });

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.performRedirect(redirectUrl, env, true);
   }
 
   /**
@@ -130,6 +130,63 @@ export default class CallHandler {
       return false;
     }
     return ["http:", "https:", "mailto:"].includes(parsedUrl.protocol);
+  }
+
+  static isAndroid(): boolean {
+    return /Android/i.test(window.navigator.userAgent);
+  }
+
+  static isExternalHttpUrl(redirectUrl: string): boolean {
+    try {
+      return ["http:", "https:"].includes(new URL(redirectUrl).protocol);
+    } catch {
+      return false;
+    }
+  }
+
+  static shouldOpenInExternalBrowser(
+    redirectUrl: string,
+    env: Pick<Env, "isRunningStandalone">,
+  ): boolean {
+    if (!env.isRunningStandalone()) {
+      return false;
+    }
+    if (redirectUrl.startsWith("../") || redirectUrl.startsWith("/")) {
+      return false;
+    }
+    return this.isExternalHttpUrl(redirectUrl);
+  }
+
+  static buildAndroidIntentUrl(redirectUrl: string): string {
+    const url = new URL(redirectUrl);
+    const path = `${url.host}${url.pathname}${url.search}`;
+    const scheme = url.protocol.replace(":", "");
+    return `intent://${path}#Intent;scheme=${scheme};S.browser_fallback_url=${encodeURIComponent(redirectUrl)};end`;
+  }
+
+  static performRedirect(
+    redirectUrl: string,
+    env: Pick<Env, "isRunningStandalone">,
+    replace = false,
+  ): void {
+    if (!this.shouldOpenInExternalBrowser(redirectUrl, env)) {
+      if (replace) {
+        window.location.replace(redirectUrl);
+      } else {
+        window.location.href = redirectUrl;
+      }
+      return;
+    }
+    if (this.isAndroid()) {
+      window.location.href = this.buildAndroidIntentUrl(redirectUrl);
+      return;
+    }
+    // Non-Android standalone: rely on handle_links:not-preferred in the manifest.
+    if (replace) {
+      window.location.replace(redirectUrl);
+    } else {
+      window.location.href = redirectUrl;
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.performRedirect(redirectUrl, envQuery);
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
Fixes #329
This PR resolves the issue where external URLs on Android standalone PWAs open inside the app instead of an external browser.
### Fix Details
1. Replaced `window.open` with `location.href` to avoid popup blocker issues inside the async environment of the PWA.
2. Built standard Android `intent://` URIs with `browser_fallback_url` so Android correctly hands the HTTP navigation off to Chrome or the default handler, effectively allowing the page to launch into a Custom Tab or the external browser instead of being trapped in the PWA standalone window.
### Evidence
Here is a screen recording from an Android device verifying that when Trovu is launched directly from the home screen icon (PWA mode without an address bar), submitting a search correctly jumps out into an external Custom Tab (displaying the address bar and X button), exactly as required.
https://github.com/chensuling57/trovu/releases/download/temp-assets/36131fef60844cb9243cf025122f198f.mp4