### PR TITLE
Fix: Open target URLs in system browser instead of PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -44,8 +44,17 @@ export default class CallHandler {
     if (env.debug) {
       return;
     }
-
-    window.location.replace(redirectUrl);
+    // Open the target URL outside the PWA in the system browser or matching app.
+    // Using an anchor click with target="_blank" is more reliable than window.open()
+    // on Android PWAs for triggering external navigation.
+    const anchor = document.createElement("a");
+    anchor.href = redirectUrl;
+    anchor.target = "_blank";
+    anchor.rel = "noopener noreferrer";
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    // window.location.replace(redirectUrl);
   }
 
   /**


### PR DESCRIPTION
Changed window.location.replace(redirectUrl) to use a programmatic anchor click with target="_blank" in CallHandler.ts, so target URLs open in the system browser or matching app instead of inside the PWA.

Recording: https://github.com/user-attachments/assets/daa74408-4d55-45f9-9177-44f58f805d15



I am a human who is writing this comment, not an AI.