### PR TITLE
Open shortcut targets outside standalone PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,6 +45,24 @@ export default class CallHandler {
       return;
     }
 
+    this.openRedirectUrl(redirectUrl, env.isRunningStandalone(), response.status === "found");
+  }
+
+  /**
+   * Redirect to Trovu pages normally, but open successful shortcut target URLs
+   * in a separate browsing context while running as an installed PWA.
+   *
+   * This avoids keeping target sites inside the standalone PWA window on
+   * platforms that honor target=_blank/window.open from standalone PWAs.
+   */
+  static openRedirectUrl(redirectUrl: string, isStandalone: boolean, isTargetUrl: boolean) {
+    if (isStandalone && isTargetUrl) {
+      const openedWindow = window.open(redirectUrl, "_blank", "noopener,noreferrer");
+      if (openedWindow) {
+        return;
+      }
+    }
+
     window.location.replace(redirectUrl);
   }
 

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,8 +394,19 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    this.openRedirectUrl(redirectUrl, response.status === "found");
   };
+
+  openRedirectUrl(redirectUrl: string, isTargetUrl: boolean) {
+    if (this.env.isRunningStandalone() && isTargetUrl) {
+      const openedWindow = window.open(redirectUrl, "_blank", "noopener,noreferrer");
+      if (openedWindow) {
+        return;
+      }
+    }
+
+    window.location.href = redirectUrl;
+  }
 
   showSubmitProgress() {
     this.queryForm.classList.add("is-submitting");


### PR DESCRIPTION
## Summary
- Open successful shortcut target URLs in a separate browsing context when Trovu runs as an installed standalone PWA.
- Keep internal Trovu redirects in the existing window.
- Fall back to the previous same-window navigation if `window.open` is blocked or unavailable.

## Testing
- `npm run typecheck`
- `npm run lint-js`

## Notes
This targets the PWA behavior where external shortcut results should not remain inside the standalone app window.
