### PR TITLE
Open target URLs not in PWA but in default browser

### DIFF
--- a/src/ts/modules/Env.test.ts
+++ b/src/ts/modules/Env.test.ts
@@ -174,6 +174,20 @@ describe("Env", () => {
     });
   });
 
+  describe("isExternalUrl", () => {
+    test("returns true for external urls", () => {
+      expect(Env.isExternalUrl("https://example.com", "https://trovu.net/index.html")).toBe(true);
+    });
+
+    test("returns false for internal urls", () => {
+      expect(Env.isExternalUrl("/process/index.html", "https://trovu.net/index.html")).toBe(false);
+    });
+
+    test("returns true for mailto urls", () => {
+      expect(Env.isExternalUrl("mailto:test@example.com", "https://trovu.net/index.html")).toBe(true);
+    });
+  });
+
   test("getParamsFromUrl", () => {
     Env.getUrlHash = getUrlHashFooBar;
     expect(Env.getParamsFromUrl()).toEqual({ query: "g foo", language: "de", debug: "1" });

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -582,4 +582,12 @@ export default class Env {
   isRunningStandalone() {
     return window.navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
   }
+
+  static isExternalUrl(url: string, baseUrl = window.location.href) {
+    try {
+      return new URL(url, baseUrl).origin !== new URL(baseUrl).origin;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -366,6 +366,8 @@ export default class Home {
     // because extraNamespace might have changed reachability,
     // or asking for a not yet parsed Github namespace.
     this.showSubmitProgress();
+    const standaloneWindow =
+      this.env.isRunningStandalone() && !this.env.debug ? window.open("", "_blank") : null;
     let envQuery: Env;
     try {
       envQuery = new Env({ context: "index" });
@@ -373,6 +375,7 @@ export default class Home {
       params.query = this.queryInput.value;
       await envQuery.populate(params);
     } catch (error) {
+      standaloneWindow?.close();
       this.hideSubmitProgress();
       throw error;
     }
@@ -394,6 +397,14 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
+
+    if (standaloneWindow && response.status === "found" && Env.isExternalUrl(redirectUrl)) {
+      standaloneWindow.location.replace(redirectUrl);
+      this.hideSubmitProgress();
+      return;
+    }
+
+    standaloneWindow?.close();
     window.location.href = redirectUrl;
   };
 

--- a/tests/playwright/home.spec.js
+++ b/tests/playwright/home.spec.js
@@ -197,6 +197,47 @@ test("Homepage should show submit progress while resolving a query", async ({ pa
   await expect(queryInput).toBeFocused();
 });
 
+test("Homepage in standalone mode should open external targets in a new window", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.matchMedia = (query) => ({
+      addEventListener() {},
+      addListener() {},
+      dispatchEvent() {
+        return false;
+      },
+      matches: query === "(display-mode: standalone)",
+      media: query,
+      onchange: null,
+      removeEventListener() {},
+      removeListener() {},
+    });
+  });
+
+  const mockGoogle = async (route) => {
+    await route.fulfill({
+      body: "<!doctype html><title>Google</title>",
+      contentType: "text/html",
+      status: 200,
+    });
+  };
+  await page.route("https://www.google.co.uk/**", mockGoogle);
+  await page.route("https://www.google.com/**", mockGoogle);
+
+  await openLoadedHomepage(page);
+
+  const popupPromise = page.waitForEvent("popup");
+  const queryInput = page.locator("#query");
+  const queryForm = page.locator("#query-form");
+
+  await queryInput.fill("g submit feedback");
+  await queryInput.press("Enter");
+
+  const popup = await popupPromise;
+  await expect(popup).toHaveURL(/google\.co\.uk/);
+  await expect(queryInput).toHaveValue("g submit feedback");
+  await expect(queryForm).not.toHaveClass(/is-submitting/);
+});
+
 test.describe("Homepage from default load", () => {
   test.beforeEach(async ({ page }) => {
     await openLoadedHomepage(page);


### PR DESCRIPTION
Keeps standalone PWA queries in the app while opening external redirect targets in a separate browser window, with a fallback for normal navigation.\n\nFixes #329.\n\nValidation:\n- Jest: src/ts/modules/Env.test.ts\n- Playwright: tests/playwright/home.spec.js (standalone mode test + normal home flow)