### PR TITLE
fix: open external links correctly from PWA

### DIFF
--- a/src/manifest/site.webmanifest
+++ b/src/manifest/site.webmanifest
@@ -1,54 +1,54 @@
 {
-    "name": "trovu.net – your web search command line",
-    "short_name": "trovu.net",
-    "description": "Search 1000+ websites in a command-line way, with curated and personal shortcuts, organized by namespaces, allowing multiple and typed arguments, with maximum privacy. It's like DuckDuckGo bangs, but on steroids. And it's free.",
-    "id": "net.trovu",
-    "scope": "/",
-    "launch_handler": {
-        "client_mode": [
-            "auto"
-        ]
-    },
-    "display_override": [
-        "standalone"
-    ],
-    "orientation": "any",
-    "screenshots": [
-        {
-            "src": "/img/screenshots/portrait.jpg",
-            "sizes": "1080x2400",
-            "type": "image/jpeg",
-            "form_factor": "narrow"
-        },
-        {
-            "src": "/img/screenshots/landscape.jpg",
-            "sizes": "2400x1080",
-            "type": "image/jpeg",
-            "form_factor": "wide"
-        }
-    ],
-    "icons": [
-        {
-            "src": "/android-chrome-192x192.png?v=2",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-512x512.png?v=2",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "background_color": "#ffffff",
-    "start_url": "/index.html",
-    "display": "standalone",
-    "prefer_related_applications": false,
-    "theme_color": "#343a40",
-    "dir": "auto",
-    "lang": "en",
-    "categories": [
-        "navigation",
-        "productivity",
-        "utilities"
+  "name": "trovu.net \u2013 your web search command line",
+  "short_name": "trovu.net",
+  "description": "Search 1000+ websites in a command-line way, with curated and personal shortcuts, organized by namespaces, allowing multiple and typed arguments, with maximum privacy. It's like DuckDuckGo bangs, but on steroids. And it's free.",
+  "id": "net.trovu",
+  "scope": "/",
+  "launch_handler": {
+    "client_mode": [
+      "auto"
     ]
+  },
+  "display_override": [
+    "standalone"
+  ],
+  "orientation": "any",
+  "screenshots": [
+    {
+      "src": "/img/screenshots/portrait.jpg",
+      "sizes": "1080x2400",
+      "type": "image/jpeg",
+      "form_factor": "narrow"
+    },
+    {
+      "src": "/img/screenshots/landscape.jpg",
+      "sizes": "2400x1080",
+      "type": "image/jpeg",
+      "form_factor": "wide"
+    }
+  ],
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png?v=2",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png?v=2",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "background_color": "#ffffff",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "prefer_related_applications": false,
+  "theme_color": "#343a40",
+  "dir": "auto",
+  "lang": "en",
+  "categories": [
+    "navigation",
+    "productivity",
+    "utilities"
+  ]
 }

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,6 +45,16 @@ export default class CallHandler {
       return;
     }
 
+    const nav = navigator as Navigator & { standalone?: boolean };
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      nav.standalone === true;
+    if (isStandalone) {
+      const popup = window.open(redirectUrl, "_blank", "noopener,noreferrer");
+      if (popup) {
+        return;
+      }
+    }
     window.location.replace(redirectUrl);
   }
 

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -15,6 +15,25 @@ import countriesList from "countries-list";
 /** Set and manage the homepage. */
 
 export default class Home {
+  /**
+   * Best-effort open outside the installed PWA shell.
+   * `location.assign` keeps navigation inside standalone WebAPK/TWA contexts;
+   * `window.open(..., "_blank")` is the portable escape hatch where the OS allows it.
+   */
+  private openExternalUrl(url: string): void {
+    const nav = navigator as Navigator & { standalone?: boolean };
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      nav.standalone === true;
+    if (isStandalone) {
+      const popup = window.open(url, "_blank", "noopener,noreferrer");
+      if (popup) {
+        return;
+      }
+    }
+    window.location.assign(url);
+  }
+
   env!: Env;
   queryInput!: HTMLInputElement;
   queryForm!: HTMLFormElement;
@@ -384,7 +403,7 @@ export default class Home {
       const processUrl = this.env.buildProcessUrl({
         query: this.queryInput.value,
       });
-      window.location.href = processUrl;
+      this.openExternalUrl(processUrl);
       return;
     }
 
@@ -394,7 +413,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    this.openExternalUrl(redirectUrl);
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
/claim #329

## Summary
Fixes external link opening behavior when running as a PWA (#329).

## Test plan
- [ ] Install as PWA
- [ ] Click an external result link — opens outside the PWA shell as expected

Made with [Cursor](https://cursor.com)