### PR TITLE
Align blog layout with main site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,6 +16,14 @@ module.exports = (eleventyConfig) => {
   // For example, `./public/css/` ends up in `_site/css/`
   eleventyConfig.addPassthroughCopy({
     "./blog/public/": ".",
+    "./src/favicon/apple-touch-icon.png": "apple-touch-icon.png",
+    "./src/favicon/favicon-16x16.png": "favicon-16x16.png",
+    "./src/favicon/favicon-32x32.png": "favicon-32x32.png",
+    "./src/favicon/favicon.ico": "favicon.ico",
+    "./src/favicon/safari-pinned-tab.svg": "safari-pinned-tab.svg",
+    "./src/img/logo.png": "img/logo.png",
+    "./src/img/og.png": "img/og.png",
+    "./src/manifest/site.webmanifest": "site.webmanifest",
     "./node_modules/prismjs/themes/prism-okaidia.css": "/css/prism-okaidia.css",
   });
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,8 @@ module.exports = (eleventyConfig) => {
     "./src/img/logo.png": "img/logo.png",
     "./src/img/og.png": "img/og.png",
     "./src/manifest/site.webmanifest": "site.webmanifest",
+    "./node_modules/@fortawesome/fontawesome-free/webfonts": "webfonts",
+    "./node_modules/bootstrap/dist/css/bootstrap.css.map": "bootstrap.css.map",
     "./node_modules/prismjs/themes/prism-okaidia.css": "/css/prism-okaidia.css",
   });
 

--- a/blog/_includes/components/site-footer.njk
+++ b/blog/_includes/components/site-footer.njk
@@ -1,25 +1,53 @@
-<footer class="navbar site-footer">
+<footer class="navbar">
   <div class="container">
-    <div class="footer-links">
+    <div class="left">
       <ul>
-        <li><a href="https://facebook.com/trovu.net">Facebook</a></li>
-        <li><a href="https://github.com/trovu">GitHub</a></li>
-        <li><a href="https://www.tiktok.com/@trovu.net">TikTok</a></li>
-        <li><a href="https://twitter.com/trovu_net">Twitter</a></li>
-        <li><a href="https://www.youtube.com/@trovu_net">YouTube</a></li>
-        <li><a href="https://jaehnig.org/impressum/">Impressum</a></li>
+        <li>
+          <a target="_blank" href="https://facebook.com/trovu.net">
+            <i class="fab fa-facebook"></i>
+          </a>
+        </li>
+        <li>
+          <a target="_blank" href="https://github.com/trovu">
+            <i class="fab fa-github"></i>
+          </a>
+        </li>
+        <li>
+          <a target="_blank" href="https://www.tiktok.com/@trovu.net">
+            <i class="fab fa-tiktok"></i>
+          </a>
+        </li>
+        <li>
+          <a target="_blank" href="https://twitter.com/trovu_net">
+            <i class="fab fa-twitter"></i>
+          </a>
+        </li>
+        <li>
+          <a target="_blank" href="https://www.youtube.com/@trovu_net">
+            <i class="fab fa-youtube"></i>
+          </a>
+        </li>
+        <li>
+          <span class="text-muted"><a href="https://jaehnig.org/impressum/">Impressum</a></span>
+        </li>
       </ul>
     </div>
-    <div class="install-links">
-      <span class="install-label">How to install</span>
-      <ul>
-        <li><a href="https://trovu.net/docs/users/integration/#chrome">Chrome</a></li>
-        <li><a href="https://trovu.net/docs/users/integration/#firefox">Firefox</a></li>
-        <li><a href="https://trovu.net/docs/users/integration/#raycast">Raycast</a></li>
-        <li><a href="https://trovu.net/docs/users/integration/#android">Android</a></li>
-        <li><a href="https://trovu.net/docs/users/integration/#pwa-progressive-web-app">PWA</a></li>
-        <li><a href="https://trovu.net/docs/users/integration/#general">Other</a></li>
-      </ul>
+    <div class="right">
+      <details class="dropdown footer-install">
+        <summary class="form-control btn btn-success">How to install</summary>
+        <div class="dropdown-menu dropdown-menu-right">
+          <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/users/integration/#chrome">Chrome</a>
+          <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/users/integration/#firefox">Firefox</a>
+          <div class="dropdown-divider"></div>
+          <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/users/integration/#raycast">Raycast</a>
+          <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/users/integration/#android">Android</a>
+          <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/users/integration/#pwa-progressive-web-app"
+            >PWA</a
+          >
+          <div class="dropdown-divider"></div>
+          <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/users/integration/#general">Other</a>
+        </div>
+      </details>
     </div>
   </div>
 </footer>

--- a/blog/_includes/components/site-footer.njk
+++ b/blog/_includes/components/site-footer.njk
@@ -1,0 +1,25 @@
+<footer class="navbar site-footer">
+  <div class="container">
+    <div class="footer-links">
+      <ul>
+        <li><a href="https://facebook.com/trovu.net">Facebook</a></li>
+        <li><a href="https://github.com/trovu">GitHub</a></li>
+        <li><a href="https://www.tiktok.com/@trovu.net">TikTok</a></li>
+        <li><a href="https://twitter.com/trovu_net">Twitter</a></li>
+        <li><a href="https://www.youtube.com/@trovu_net">YouTube</a></li>
+        <li><a href="https://jaehnig.org/impressum/">Impressum</a></li>
+      </ul>
+    </div>
+    <div class="install-links">
+      <span class="install-label">How to install</span>
+      <ul>
+        <li><a href="https://trovu.net/docs/users/integration/#chrome">Chrome</a></li>
+        <li><a href="https://trovu.net/docs/users/integration/#firefox">Firefox</a></li>
+        <li><a href="https://trovu.net/docs/users/integration/#raycast">Raycast</a></li>
+        <li><a href="https://trovu.net/docs/users/integration/#android">Android</a></li>
+        <li><a href="https://trovu.net/docs/users/integration/#pwa-progressive-web-app">PWA</a></li>
+        <li><a href="https://trovu.net/docs/users/integration/#general">Other</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>

--- a/blog/_includes/components/site-header.njk
+++ b/blog/_includes/components/site-header.njk
@@ -26,6 +26,19 @@
           </a>
         </li>
       </ul>
+      <details class="site-menu">
+        <summary aria-label="Open navigation menu">
+          <span class="navbar-toggler-icon"></span>
+        </summary>
+        <div class="site-menu-panel">
+          <a href="https://trovu.net/">Search</a>
+          <a href="https://trovu.net/docs/">Docs</a>
+          <a href="/">Blog</a>
+          <a href="https://trovu.net/docs/privacy/">Privacy</a>
+          <a href="https://github.com/trovu/trovu">GitHub</a>
+          <a href="/feed/">RSS feed</a>
+        </div>
+      </details>
     </div>
   </nav>
 </header>

--- a/blog/_includes/components/site-header.njk
+++ b/blog/_includes/components/site-header.njk
@@ -1,0 +1,31 @@
+<header class="site-header">
+  <nav class="navbar navbar-expand-md navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand trovu-brand" href="https://trovu.net/" aria-label="trovu.net search">
+        <img src="/img/logo.png" alt="trovu.net" class="logo">
+      </a>
+      <ul class="navbar-nav site-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="https://trovu.net/">Search</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://trovu.net/docs/">Docs</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link active" href="/" aria-current="page">Blog</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://trovu.net/docs/privacy/">Privacy</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://github.com/trovu/trovu">GitHub</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link feed-link" href="/feed/" aria-label="RSS feed">
+            <img src="/img/rss.svg" width="14" height="14" alt="">
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>

--- a/blog/_includes/components/site-header.njk
+++ b/blog/_includes/components/site-header.njk
@@ -2,8 +2,8 @@
   <nav class="navbar navbar-expand-md navbar-dark bg-dark">
     <div class="container">
       <div class="left">
-        <a href="https://trovu.net/" aria-label="trovu.net search">
-          <img src="/img/logo.png" alt="trovu.net" class="logo">
+        <a href="https://trovu.net/">
+          <img src="/img/logo.png" alt="Logo" class="logo">
         </a>
       </div>
       <div class="right">
@@ -29,17 +29,18 @@
             </a>
           </li>
         </ul>
-        <details class="site-menu">
+        <details class="dropdown site-menu">
           <summary aria-label="Open navigation menu">
             <span class="navbar-toggler-icon"></span>
           </summary>
-          <div class="site-menu-panel">
-            <a href="https://trovu.net/">Search</a>
-            <a href="https://trovu.net/docs/">Docs</a>
-            <a href="/">Blog</a>
-            <a href="https://trovu.net/docs/privacy/">Privacy</a>
-            <a href="https://github.com/trovu/trovu">GitHub</a>
-            <a href="/feed/">RSS feed</a>
+          <div class="dropdown-menu dropdown-menu-right site-menu-panel">
+            <a target="_blank" class="dropdown-item" href="https://trovu.net/">Search</a>
+            <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/">Docs</a>
+            <a class="dropdown-item" href="/">Blog</a>
+            <a target="_blank" class="dropdown-item" href="https://trovu.net/docs/privacy/">Privacy</a>
+            <div class="dropdown-divider"></div>
+            <a target="_blank" class="dropdown-item" href="https://github.com/trovu/trovu">GitHub</a>
+            <a class="dropdown-item" href="/feed/">RSS feed</a>
           </div>
         </details>
       </div>

--- a/blog/_includes/components/site-header.njk
+++ b/blog/_includes/components/site-header.njk
@@ -1,44 +1,48 @@
 <header class="site-header">
   <nav class="navbar navbar-expand-md navbar-dark bg-dark">
     <div class="container">
-      <a class="navbar-brand trovu-brand" href="https://trovu.net/" aria-label="trovu.net search">
-        <img src="/img/logo.png" alt="trovu.net" class="logo">
-      </a>
-      <ul class="navbar-nav site-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="https://trovu.net/">Search</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://trovu.net/docs/">Docs</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="/" aria-current="page">Blog</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://trovu.net/docs/privacy/">Privacy</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://github.com/trovu/trovu">GitHub</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link feed-link" href="/feed/" aria-label="RSS feed">
-            <img src="/img/rss.svg" width="14" height="14" alt="">
-          </a>
-        </li>
-      </ul>
-      <details class="site-menu">
-        <summary aria-label="Open navigation menu">
-          <span class="navbar-toggler-icon"></span>
-        </summary>
-        <div class="site-menu-panel">
-          <a href="https://trovu.net/">Search</a>
-          <a href="https://trovu.net/docs/">Docs</a>
-          <a href="/">Blog</a>
-          <a href="https://trovu.net/docs/privacy/">Privacy</a>
-          <a href="https://github.com/trovu/trovu">GitHub</a>
-          <a href="/feed/">RSS feed</a>
-        </div>
-      </details>
+      <div class="left">
+        <a href="https://trovu.net/" aria-label="trovu.net search">
+          <img src="/img/logo.png" alt="trovu.net" class="logo">
+        </a>
+      </div>
+      <div class="right">
+        <ul class="navbar-nav site-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="https://trovu.net/">Search</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://trovu.net/docs/">Docs</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active" href="/" aria-current="page">Blog</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://trovu.net/docs/privacy/">Privacy</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://github.com/trovu/trovu">GitHub</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link feed-link" href="/feed/" aria-label="RSS feed">
+              <img src="/img/rss.svg" width="14" height="14" alt="">
+            </a>
+          </li>
+        </ul>
+        <details class="site-menu">
+          <summary aria-label="Open navigation menu">
+            <span class="navbar-toggler-icon"></span>
+          </summary>
+          <div class="site-menu-panel">
+            <a href="https://trovu.net/">Search</a>
+            <a href="https://trovu.net/docs/">Docs</a>
+            <a href="/">Blog</a>
+            <a href="https://trovu.net/docs/privacy/">Privacy</a>
+            <a href="https://github.com/trovu/trovu">GitHub</a>
+            <a href="/feed/">RSS feed</a>
+          </div>
+        </details>
+      </div>
     </div>
   </nav>
 </header>

--- a/blog/_includes/layouts/base.njk
+++ b/blog/_includes/layouts/base.njk
@@ -1,62 +1,40 @@
 <!doctype html>
 <html lang="{{ metadata.language }}">
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<title>{{ title or metadata.title }}</title>
-		<meta name="description" content="{{ description or metadata.description }}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>{{ title or metadata.title }}</title>
+    <meta name="description" content="{{ description or metadata.description }}">
+    <meta property="og:image" content="https://trovu.net/img/og.png">
+    <meta property="og:title" content="{{ title or metadata.title }}">
+    <meta property="og:url" content="{{ page.url | htmlBaseUrl(metadata.url) }}">
+    <meta property="og:site_name" content="trovu.net">
+    <meta property="og:description" content="{{ description or metadata.description }}">
+    <meta property="og:type" content="{% if page.url == '/' %}website{% else %}article{% endif %}">
+    <meta name="msapplication-TileColor" content="#487b7f">
+    <meta name="theme-color" content="#343a40">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=3">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=3">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=3">
+    <link rel="manifest" href="/site.webmanifest?v=3">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg?v=3" color="#487b7f">
+    <link rel="shortcut icon" href="/favicon.ico?v=3">
+    <link rel="alternate" href="/feed/" type="application/atom+xml" title="{{ metadata.title }}">
 
-		{#- Atom and JSON feeds included by default #}
-		<link rel="alternate" href="/feed/" type="application/atom+xml" title="{{ metadata.title }}">
+    {%- css %}* { box-sizing: border-box; }{% endcss %}
+    {%- css %}{% include "node_modules/bootstrap/dist/css/bootstrap.css" %}{% endcss %}
+    {%- css %}{% include "blog/public/css/index.css" %}{% endcss %}
 
-		{#- Uncomment this if you’d like folks to know that you used Eleventy to build your site!  #}
-		{#- <meta name="generator" content="{{ eleventy.generator }}"> #}
+    <style>{% getBundle "css" %}</style>
+  </head>
+  <body>
+    <a href="#skip" class="visually-hidden">Skip to main content</a>
+    {% include "components/site-header.njk" %}
+    <main id="skip" class="site-main container">
+      {{ content | safe }}
+    </main>
+    {% include "components/site-footer.njk" %}
 
-		{#-
-		CSS bundles are provided via the `eleventy-plugin-bundle` plugin:
-		1. You can add to them using `{% css %}`
-		2. You can get from them using `{% getBundle "css" %}` or `{% getBundleFileUrl "css" %}`
-		3. You can do the same for JS: {% js %}{% endjs %} and <script>{% getBundle "js" %}</script>
-		4. Learn more: https://github.com/11ty/eleventy-plugin-bundle
-		#}
-
-		{#- Add an arbitrary string to the bundle #}
-		{%- css %}* { box-sizing: border-box; }{% endcss %}
-		{#- Add the contents of a file to the bundle #}
-		{%- css %}{% include "blog/public/css/index.css" %}{% endcss %}
-		{#- Or add from node_modules #}
-		{# {%- css %}{% include "node_modules/prismjs/themes/prism-okaidia.css" %}{% endcss %} #}
-
-		{#- Render the CSS bundle using Inlined CSS (for the fastest site performance in production) #}
-		<style>{% getBundle "css" %}</style>
-		{#- Renders the CSS bundle using a separate file, if you can't set CSP directive style-src: 'unsafe-inline' #}
-		{#- <link rel="stylesheet" href="{% getBundleFileUrl "css" %}"> #}
-	</head>
-	<body>
-		<a href="#skip" class="visually-hidden">Skip to main content</a>
-
-		<header>
-			<a href="/" class="home-link">{{ metadata.title }}</a>
-
-			{#- Read more about `eleventy-navigation` at https://www.11ty.dev/docs/plugins/navigation/ #}
-			<nav>
-				<h2 class="visually-hidden">Top level navigation menu</h2>
-				<ul class="nav">
-					<li class="nav-item"><a href="../../">Home</a></li>
-					<li class="nav-item"><a href="../../docs/">Docs</a></li>
-					<li class="nav-item"><a href="../../docs/privacy">Privacy</a></li>
-					<li class="nav-item"><a href="https://github.com/trovu/">Github</a></li>
-					<li class="nav-item"><a href="/feed/"><img src="/img/rss.svg" width="14" height="14"></a></li>
-				</ul>
-			</nav>
-		</header>
-
-		<main id="skip">
-			{{ content | safe }}
-		</main>
-
-		<footer></footer>
-
-		<!-- Current page: {{ page.url | htmlBaseUrl }} -->
-	</body>
+    <!-- Current page: {{ page.url | htmlBaseUrl }} -->
+  </body>
 </html>

--- a/blog/_includes/layouts/base.njk
+++ b/blog/_includes/layouts/base.njk
@@ -23,6 +23,7 @@
 
     {%- css %}* { box-sizing: border-box; }{% endcss %}
     {%- css %}{% include "node_modules/bootstrap/dist/css/bootstrap.css" %}{% endcss %}
+    {%- css %}{% include "node_modules/@fortawesome/fontawesome-free/css/all.min.css" %}{% endcss %}
     {%- css %}{% include "blog/public/css/index.css" %}{% endcss %}
 
     <style>{% getBundle "css" %}</style>

--- a/blog/_includes/layouts/post.njk
+++ b/blog/_includes/layouts/post.njk
@@ -4,6 +4,7 @@ layout: layouts/base.njk
 {# Only include the syntax highlighter CSS on blog posts #}
 {%- css %}{% include "node_modules/prismjs/themes/prism-okaidia.css" %}{% endcss %}
 {%- css %}{% include "blog/public/css/prism-diff.css" %}{%- endcss %}
+<article class="blog-post">
 <h1>{{ title }}</h1>
 
 <ul class="post-metadata">
@@ -15,6 +16,7 @@ layout: layouts/base.njk
 </ul>
 
 {{ content | safe }}
+</article>
 
 {%- if collections.posts %}
 {%- set previousPost = collections.posts | getPreviousCollectionItem %}

--- a/blog/index.njk
+++ b/blog/index.njk
@@ -5,5 +5,12 @@ eleventyNavigation:
   order: 1
 ---
 
+<section class="blog-intro">
+  <h1>Blog</h1>
+  <p class="tagline">
+    <span class="highlight">News</span> and stories from trovu.net, your web search command line.
+  </p>
+</section>
+
 {% set postslist = collections.posts %}
 {% include "postslist.njk" %}

--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -91,15 +91,15 @@ img {
   width: 1px;
 }
 
-.site-header .navbar {
+header .navbar {
   margin-bottom: 1em;
 }
 
-.site-header .container {
+.navbar .container {
   padding: 0 2em;
 }
 
-.site-header .container img.logo {
+.navbar .container img.logo {
   height: 50px;
   margin: 0;
   padding: 0;
@@ -108,7 +108,7 @@ img {
   width: auto;
 }
 
-.site-header .right {
+header .right {
   align-items: center;
   display: flex;
   margin-left: auto;
@@ -145,45 +145,33 @@ img {
   position: relative;
 }
 
-.site-menu summary {
+.site-menu summary,
+.footer-install summary {
   align-items: center;
   cursor: pointer;
   display: flex;
-  height: 1.8rem;
   justify-content: center;
   list-style: none;
+}
+
+.site-menu summary {
+  height: 1.8rem;
   width: 1.8rem;
 }
 
-.site-menu summary::-webkit-details-marker {
+.site-menu summary::-webkit-details-marker,
+.footer-install summary::-webkit-details-marker {
   display: none;
 }
 
-.site-menu-panel {
-  background: #fff;
-  border: 1px solid var(--trovu-border);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-  min-width: 12rem;
-  padding: 0.4rem 0;
-  position: absolute;
+.site-menu[open] .dropdown-menu,
+.footer-install[open] .dropdown-menu {
+  display: block;
+}
+
+.site-menu .dropdown-menu {
   right: 0;
   top: calc(100% + 0.4rem);
-  z-index: 10;
-}
-
-.site-menu-panel a {
-  color: #333;
-  display: block;
-  padding: 0.45rem 0.9rem;
-  white-space: nowrap;
-}
-
-.site-footer .container {
-  align-items: center;
-  display: flex;
-  gap: 1rem;
-  justify-content: space-between;
-  padding: 0 2em;
 }
 
 .site-main {
@@ -433,48 +421,40 @@ img.full-width {
   width: 100%;
 }
 
-.site-footer {
+.footer-install {
+  position: relative;
+}
+
+.footer-install .dropdown-menu {
+  right: 0;
+}
+
+footer.navbar {
   background: var(--trovu-footer);
   flex-shrink: 0;
   margin-top: 1em;
-  padding: 1rem 0;
+  padding: 0;
+  padding-bottom: 1em;
 }
 
-.site-footer ul {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem 0.75rem;
+footer.navbar .left ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.site-footer li {
-  margin: 0;
+footer.navbar .left li {
+  display: inline;
+  margin-bottom: 0;
+  margin-right: 0.5em;
 }
 
-.site-footer a {
+footer.navbar a {
   color: rgb(13, 110, 253);
 }
 
-.install-links {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem 0.75rem;
-  justify-content: flex-end;
-}
-
-.install-label {
-  background: #198754;
-  border-radius: 0.375rem;
-  color: #fff;
-  display: inline-block;
-  padding: 0.375rem 0.75rem;
-}
-
 @media (max-width: 767.98px) {
-  .site-header .container {
+  .navbar .container {
     padding: 0 1rem;
   }
 
@@ -486,7 +466,7 @@ img.full-width {
     display: block;
   }
 
-  .site-footer .container {
+  footer.navbar .container {
     align-items: flex-start;
     flex-direction: column;
     padding: 0 1rem;
@@ -501,7 +481,8 @@ img.full-width {
     grid-template-columns: 2rem 1fr;
   }
 
-  .install-links {
-    justify-content: flex-start;
+  .footer-install .dropdown-menu {
+    left: 0;
+    right: auto;
   }
 }

--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -455,7 +455,12 @@ footer.navbar a {
 
 @media (max-width: 767.98px) {
   .navbar .container {
-    padding: 0 1rem;
+    padding: 0 2em;
+  }
+
+  .navbar .container img.logo {
+    margin-top: -13px;
+    top: auto;
   }
 
   .site-nav {

--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -92,7 +92,10 @@ img {
 }
 
 .site-header .navbar {
-  margin-bottom: 1em;
+  margin-bottom: 2em;
+  min-height: 2.5rem;
+  padding-bottom: 0.35rem;
+  padding-top: 0.35rem;
 }
 
 .site-header .container,
@@ -104,16 +107,25 @@ img {
   padding: 0 2em;
 }
 
+.site-header .container {
+  min-height: 2rem;
+  position: relative;
+}
+
 .trovu-brand {
-  align-items: center;
-  display: inline-flex;
-  min-height: 50px;
+  display: block;
+  flex: 0 0 15rem;
+  height: 2rem;
   padding: 0;
 }
 
 .trovu-brand img.logo {
-  display: block;
   height: 50px;
+  left: 2em;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 0.6rem;
   width: auto;
 }
 
@@ -140,6 +152,10 @@ img {
   align-items: center;
   display: inline-flex;
   min-height: 2rem;
+}
+
+.site-menu {
+  display: none;
 }
 
 .site-main {
@@ -430,15 +446,68 @@ img.full-width {
 }
 
 @media (max-width: 767.98px) {
-  .site-header .container,
+  .site-header .container {
+    align-items: center;
+    flex-direction: row;
+    padding: 0 1rem;
+  }
+
   .site-footer .container {
     align-items: flex-start;
     flex-direction: column;
     padding: 0 1rem;
   }
 
+  .trovu-brand {
+    flex-basis: 14rem;
+    height: 2rem;
+  }
+
+  .trovu-brand img.logo {
+    left: 1rem;
+  }
+
   .site-nav {
-    justify-content: flex-start;
+    display: none;
+  }
+
+  .site-menu {
+    display: block;
+    margin-left: auto;
+    position: relative;
+  }
+
+  .site-menu summary {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    height: 2rem;
+    justify-content: center;
+    list-style: none;
+    width: 2rem;
+  }
+
+  .site-menu summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .site-menu-panel {
+    background: #fff;
+    border: 1px solid var(--trovu-border);
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    min-width: 12rem;
+    padding: 0.4rem 0;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.4rem);
+    z-index: 10;
+  }
+
+  .site-menu-panel a {
+    color: #333;
+    display: block;
+    padding: 0.45rem 0.9rem;
+    white-space: nowrap;
   }
 
   .site-main {

--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -102,9 +102,9 @@ img {
 .site-header .container img.logo {
   height: 50px;
   margin: 0;
-  margin-top: -13px;
   padding: 0;
   position: absolute;
+  top: 0.3rem;
   width: auto;
 }
 
@@ -116,7 +116,7 @@ img {
 
 .site-nav {
   align-items: center;
-  display: none;
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   gap: 0.1rem 0.5rem;
@@ -125,7 +125,7 @@ img {
 
 .site-nav .nav-link {
   color: rgba(255, 255, 255, 0.78);
-  padding: 0.35rem 0.4rem;
+  padding: 0 0.4rem;
 }
 
 .site-nav .nav-link.active,
@@ -137,11 +137,10 @@ img {
 .site-nav .feed-link {
   align-items: center;
   display: inline-flex;
-  min-height: 2rem;
 }
 
 .site-menu {
-  display: block;
+  display: none;
   margin-left: auto;
   position: relative;
 }
@@ -477,6 +476,14 @@ img.full-width {
 @media (max-width: 767.98px) {
   .site-header .container {
     padding: 0 1rem;
+  }
+
+  .site-nav {
+    display: none;
+  }
+
+  .site-menu {
+    display: block;
   }
 
   .site-footer .container {

--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -1,64 +1,86 @@
-/* Defaults */
+/* Trovu blog layout. Keep this close to src/html/index.html and src/scss/style.scss. */
 :root {
-  --font-family: -apple-system, system-ui, sans-serif;
-  --font-family-monospace: Consolas, Menlo, Monaco, Andale Mono WT, Andale Mono,
-    Lucida Console, Lucida Sans Typewriter, DejaVu Sans Mono,
-    Bitstream Vera Sans Mono, Liberation Mono, Nimbus Mono L, Courier New,
-    Courier, monospace;
-}
-
-/* Theme colors */
-:root {
-  --color-gray-20: #e0e0e0;
-  --color-gray-50: #c0c0c0;
-  --color-gray-90: #333;
-
-  --background-color: #fff;
-
-  --text-color: var(--color-gray-90);
-  --text-color-link: #082840;
-  --text-color-link-active: #5f2b48;
-  --text-color-link-visited: #17050f;
-
+  --trovu-teal: #487b7f;
+  --trovu-teal-text: #477b7f;
+  --trovu-dark: #343a40;
+  --trovu-yellow: #ffc107;
+  --trovu-footer: #eee;
+  --trovu-border: #eee;
+  --trovu-muted: #6c757d;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-family-monospace: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console",
+    "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L",
+    "Courier New", Courier, monospace;
   --syntax-tab-size: 2;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-gray-20: #e0e0e0;
-    --color-gray-50: #c0c0c0;
-    --color-gray-90: #dad8d8;
-
-    /* --text-color is assigned to --color-gray-_ above */
-    --text-color-link: #1493fb;
-    --text-color-link-active: #6969f7;
-    --text-color-link-visited: #a6a6f8;
-
-    --background-color: #15202b;
-  }
-}
-
-/* Global stylesheet */
-* {
-  box-sizing: border-box;
 }
 
 html,
 body {
-  padding: 0;
-  margin: 0 auto;
-  font-family: var(--font-family);
-  color: var(--text-color);
-  background-color: var(--background-color);
+  min-height: 100%;
+  margin: 0;
 }
+
 html {
   overflow-y: scroll;
 }
+
 body {
-  max-width: 40em;
+  background: #fff;
+  color: #333;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-family);
 }
 
-/* https://www.a11yproject.com/posts/how-to-hide-content/ */
+body,
+button,
+input,
+textarea,
+select {
+  letter-spacing: 0;
+}
+
+a {
+  color: rgb(13, 110, 253);
+  text-decoration: none;
+}
+
+a:hover,
+a:active {
+  text-decoration: underline;
+}
+
+p,
+li {
+  line-height: 1.55;
+}
+
+pre,
+code {
+  font-family: var(--font-family-monospace);
+}
+
+pre:not([class*="language-"]) {
+  direction: ltr;
+  hyphens: none;
+  line-height: 1.375;
+  margin: 0.5em 0;
+  tab-size: var(--syntax-tab-size);
+  text-align: left;
+  white-space: pre;
+  word-break: normal;
+  word-spacing: normal;
+}
+
+code {
+  color: #444;
+  word-break: break-word;
+}
+
+img {
+  max-width: 100%;
+}
+
 .visually-hidden {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
@@ -69,241 +91,366 @@ body {
   width: 1px;
 }
 
-p:last-child {
-  margin-bottom: 0;
+.site-header .navbar {
+  margin-bottom: 1em;
 }
-p {
+
+.site-header .container,
+.site-footer .container {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0 2em;
+}
+
+.trovu-brand {
+  align-items: center;
+  display: inline-flex;
+  min-height: 50px;
+  padding: 0;
+}
+
+.trovu-brand img.logo {
+  display: block;
+  height: 50px;
+  width: auto;
+}
+
+.site-nav {
+  align-items: center;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.1rem 0.5rem;
+  justify-content: flex-end;
+}
+
+.site-nav .nav-link {
+  color: rgba(255, 255, 255, 0.78);
+  padding: 0.35rem 0.4rem;
+}
+
+.site-nav .nav-link.active,
+.site-nav .nav-link:hover,
+.site-nav .nav-link:focus {
+  color: #fff;
+}
+
+.site-nav .feed-link {
+  align-items: center;
+  display: inline-flex;
+  min-height: 2rem;
+}
+
+.site-main {
+  flex: 1 0 auto;
+  padding-bottom: 2rem;
+}
+
+.blog-intro,
+.blog-post,
+.links-nextprev,
+.tag-page,
+.site-main > h1,
+.site-main > p,
+.site-main > ul {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 46rem;
+}
+
+.blog-intro {
+  margin-top: 1.5em;
+  text-align: center;
+}
+
+.blog-intro h1,
+.blog-post h1,
+.site-main > h1 {
+  color: var(--trovu-teal-text);
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 500;
+  margin: 0 0 0.35em;
+}
+
+.blog-intro .tagline {
+  color: var(--trovu-teal-text);
+  font-size: 1.2em;
+  font-style: italic;
   line-height: 1.5;
+  margin: 0 auto 1.5em;
+  max-width: 42rem;
 }
 
-li {
+span.highlight,
+.highlight {
+  background: transparent;
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 193, 7, 0.1),
+    rgba(255, 193, 7, 0.7) 4%,
+    rgba(255, 193, 7, 0.3)
+  );
+  border-radius: 0.8em 0.3em;
+  box-decoration-break: clone;
+  margin: 0 -0.2em;
+  padding: 0.1em 0.4em;
+  -webkit-box-decoration-break: clone;
+}
+
+.postlist {
+  list-style: none;
+  margin: 1.5rem auto 0;
+  max-width: 46rem;
+  padding: 0;
+}
+
+.postlist-item {
+  border-top: 1px solid var(--trovu-border);
+  counter-increment: start-from -1;
+  display: grid;
+  gap: 0.2rem 1rem;
+  grid-template-columns: minmax(2.5rem, auto) 1fr;
+  padding: 1rem 0;
+}
+
+.postlist-item:last-child {
+  border-bottom: 1px solid var(--trovu-border);
+}
+
+.postlist-item::before {
+  color: #aaa;
+  content: counter(start-from, decimal-leading-zero) ".";
+  font-size: 0.9rem;
+  grid-row: 1 / span 3;
   line-height: 1.5;
+  text-align: right;
 }
 
-a[href] {
-  color: var(--text-color-link);
-}
-a[href]:visited {
-  color: var(--text-color-link-visited);
-}
-a[href]:hover,
-a[href]:active {
-  color: var(--text-color-link-active);
+.postlist-description {
+  color: var(--trovu-muted);
+  font-size: 0.95rem;
+  grid-column: 2;
+  margin: 0;
+  order: 2;
 }
 
-main {
-  padding: 1rem;
-}
-main :first-child {
-  margin-top: 0;
+.postlist-link {
+  color: #333;
+  font-size: 1.2rem;
+  font-weight: 700;
+  grid-column: 2;
+  line-height: 1.35;
+  order: 1;
 }
 
-header {
-  border-bottom: 1px dashed var(--color-gray-20);
+.postlist-link:visited {
+  color: #333;
 }
-header:after {
-  content: '';
-  display: table;
-  clear: both;
+
+.postlist-link:hover,
+.postlist-link:focus {
+  color: rgb(13, 110, 253);
+}
+
+.postlist-date {
+  color: #777;
+  font-size: 0.85rem;
+  grid-column: 2;
+  order: 3;
+}
+
+.postlist-item-active .postlist-link {
+  color: var(--trovu-teal);
+}
+
+.blog-post {
+  font-size: 1.05rem;
+  padding-top: 1rem;
+}
+
+.blog-post h1 {
+  line-height: 1.15;
+}
+
+.blog-post h2,
+.blog-post h3,
+.blog-post h4 {
+  color: var(--trovu-teal-text);
+  margin-top: 1.8em;
+}
+
+.blog-post p,
+.blog-post ul,
+.blog-post ol,
+.blog-post blockquote,
+.blog-post pre,
+.blog-post table,
+.blog-post picture,
+.blog-post > div {
+  margin-bottom: 1.1rem;
+}
+
+.blog-post blockquote {
+  border-left: 0.25rem solid rgba(72, 123, 127, 0.35);
+  color: #555;
+  padding-left: 1rem;
+}
+
+.blog-post table {
+  width: 100%;
+}
+
+.blog-post table td,
+.blog-post table th {
+  border-bottom: 1px solid var(--trovu-border);
+  padding: 0.45em 1em 0.45em 0;
+}
+
+.post-metadata {
+  color: #777;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.6rem;
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+}
+
+.post-tag {
+  background: var(--trovu-yellow);
+  border-radius: 0.2rem;
+  color: #000;
+  display: inline-flex;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  padding: 0.05em 0.4em;
+  white-space: nowrap;
+}
+
+.post-tag:visited {
+  color: #000;
 }
 
 .links-nextprev {
-  list-style: none;
-  border-top: 1px dashed var(--color-gray-20);
-  padding: 1em 0;
-}
-
-table {
-  margin: 1em 0;
-}
-table td,
-table th {
-  padding-right: 1em;
-}
-
-pre,
-code {
-  font-family: var(--font-family-monospace);
-}
-pre:not([class*='language-']) {
-  margin: 0.5em 0;
-  line-height: 1.375; /* 22px /16 */
-  -moz-tab-size: var(--syntax-tab-size);
-  -o-tab-size: var(--syntax-tab-size);
-  tab-size: var(--syntax-tab-size);
-  -webkit-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-}
-code {
-  word-break: break-all;
-}
-
-/* Header */
-header {
-  display: flex;
-  gap: 1em 0.5em;
-  flex-wrap: wrap;
-  align-items: center;
-  padding: 1em;
-}
-.home-link {
-  font-size: 1em; /* 16px /16 */
-  font-weight: 700;
-  margin-right: 2em;
-}
-.home-link:link:not(:hover) {
-  text-decoration: none;
-}
-
-/* Nav */
-.nav {
-  display: flex;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-.nav-item {
-  display: inline-block;
-  margin-right: 1em;
-}
-.nav-item a[href]:not(:hover) {
-  text-decoration: none;
-}
-.nav a[href][aria-current='page'] {
-  text-decoration: underline;
-}
-
-/* Posts list */
-.postlist {
-  list-style: none;
-  padding: 0;
-  padding-left: 1.5rem;
-}
-.postlist-item {
+  border-top: 1px solid var(--trovu-border);
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
-  counter-increment: start-from -1;
-  margin-bottom: 1em;
-}
-.postlist-item:before {
-  display: inline-block;
-  pointer-events: none;
-  content: '' counter(start-from, decimal-leading-zero) '. ';
-  line-height: 100%;
-  text-align: right;
-  margin-left: -1.5rem;
-}
-.postlist-description {
-  flex-basis: 100%;
-}
-.postlist-date,
-.postlist-item:before {
-  font-size: 0.8125em; /* 13px /16 */
-  color: var(--color-gray-90);
-}
-.postlist-date {
-  word-spacing: -0.5px;
-}
-.postlist-link {
-  font-size: 1.1875em; /* 19px /16 */
-  font-weight: 700;
-  flex-basis: calc(100% - 1.5rem);
-  padding-left: 0.25em;
-  padding-right: 0.5em;
-  text-underline-position: from-font;
-  text-underline-offset: 0;
-  text-decoration-thickness: 1px;
-}
-.postlist-item-active .postlist-link {
-  font-weight: bold;
-}
-
-/* Tags */
-.post-tag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-style: italic;
-}
-.postlist-item > .post-tag {
-  align-self: center;
-}
-
-/* Tags list */
-.post-metadata {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 0.5em;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
   list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.post-metadata time {
-  margin-right: 1em;
+  margin-top: 2rem;
+  padding: 1rem 0 0;
 }
 
-/* Direct Links / Markdown Headers */
 .header-anchor {
-  text-decoration: none;
-  font-style: normal;
-  font-size: 1em;
-  margin-left: 0.1em;
-}
-a[href].header-anchor,
-a[href].header-anchor:visited {
   color: transparent;
+  font-size: 0.9em;
+  margin-left: 0.1em;
+  text-decoration: none;
 }
-a[href].header-anchor:focus,
-a[href].header-anchor:hover {
-  text-decoration: underline;
-}
-a[href].header-anchor:focus,
-:hover > a[href].header-anchor {
+
+.header-anchor:focus,
+:hover > .header-anchor {
   color: #aaa;
 }
 
-h2 + .header-anchor {
-  font-size: 1.5em;
-}
 main li {
-  margin-bottom: 1em;
+  margin-bottom: 0.7em;
 }
 
 div.trovu-call {
+  background: var(--trovu-teal);
+  color: #fff;
   display: block;
-  background: #487b7f;
-  color: white;
-  margin: 0;
-  padding: 0;
-  border: 0;
+  margin: 1rem 0;
 }
+
 div.trovu-call a,
 div.trovu-call a:link,
 div.trovu-call a:visited {
+  color: #fff;
   display: inline-block;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  text-decoration: none;
-  color: white;
-  padding: 0.4em;
+  font-family: var(--font-family-monospace);
   margin: 0;
-  border: 0;
+  padding: 0.4em;
+  text-decoration: none;
 }
 
 div.trovu-call span {
   background: #aaa;
-  padding: 0.4em;
+  display: inline-block;
   margin: 0;
-  border: 0;
+  padding: 0.4em;
 }
 
 img.full-width {
-  width: 100%;
   height: auto;
+  width: 100%;
+}
+
+.site-footer {
+  background: var(--trovu-footer);
+  flex-shrink: 0;
+  margin-top: 1em;
+  padding: 1rem 0;
+}
+
+.site-footer ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-footer li {
+  margin: 0;
+}
+
+.site-footer a {
+  color: rgb(13, 110, 253);
+}
+
+.install-links {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  justify-content: flex-end;
+}
+
+.install-label {
+  background: #198754;
+  border-radius: 0.375rem;
+  color: #fff;
+  display: inline-block;
+  padding: 0.375rem 0.75rem;
+}
+
+@media (max-width: 767.98px) {
+  .site-header .container,
+  .site-footer .container {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 0 1rem;
+  }
+
+  .site-nav {
+    justify-content: flex-start;
+  }
+
+  .site-main {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .postlist-item {
+    grid-template-columns: 2rem 1fr;
+  }
+
+  .install-links {
+    justify-content: flex-start;
+  }
 }

--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -92,45 +92,31 @@ img {
 }
 
 .site-header .navbar {
-  margin-bottom: 2em;
-  min-height: 2.5rem;
-  padding-bottom: 0.35rem;
-  padding-top: 0.35rem;
-}
-
-.site-header .container,
-.site-footer .container {
-  align-items: center;
-  display: flex;
-  gap: 1rem;
-  justify-content: space-between;
-  padding: 0 2em;
+  margin-bottom: 1em;
 }
 
 .site-header .container {
-  min-height: 2rem;
-  position: relative;
+  padding: 0 2em;
 }
 
-.trovu-brand {
-  display: block;
-  flex: 0 0 15rem;
-  height: 2rem;
-  padding: 0;
-}
-
-.trovu-brand img.logo {
+.site-header .container img.logo {
   height: 50px;
-  left: 2em;
   margin: 0;
+  margin-top: -13px;
   padding: 0;
   position: absolute;
-  top: 0.6rem;
   width: auto;
+}
+
+.site-header .right {
+  align-items: center;
+  display: flex;
+  margin-left: auto;
 }
 
 .site-nav {
   align-items: center;
+  display: none;
   flex-direction: row;
   flex-wrap: wrap;
   gap: 0.1rem 0.5rem;
@@ -155,7 +141,50 @@ img {
 }
 
 .site-menu {
+  display: block;
+  margin-left: auto;
+  position: relative;
+}
+
+.site-menu summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 1.8rem;
+  justify-content: center;
+  list-style: none;
+  width: 1.8rem;
+}
+
+.site-menu summary::-webkit-details-marker {
   display: none;
+}
+
+.site-menu-panel {
+  background: #fff;
+  border: 1px solid var(--trovu-border);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  min-width: 12rem;
+  padding: 0.4rem 0;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  z-index: 10;
+}
+
+.site-menu-panel a {
+  color: #333;
+  display: block;
+  padding: 0.45rem 0.9rem;
+  white-space: nowrap;
+}
+
+.site-footer .container {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0 2em;
 }
 
 .site-main {
@@ -447,8 +476,6 @@ img.full-width {
 
 @media (max-width: 767.98px) {
   .site-header .container {
-    align-items: center;
-    flex-direction: row;
     padding: 0 1rem;
   }
 
@@ -456,58 +483,6 @@ img.full-width {
     align-items: flex-start;
     flex-direction: column;
     padding: 0 1rem;
-  }
-
-  .trovu-brand {
-    flex-basis: 14rem;
-    height: 2rem;
-  }
-
-  .trovu-brand img.logo {
-    left: 1rem;
-  }
-
-  .site-nav {
-    display: none;
-  }
-
-  .site-menu {
-    display: block;
-    margin-left: auto;
-    position: relative;
-  }
-
-  .site-menu summary {
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-    height: 2rem;
-    justify-content: center;
-    list-style: none;
-    width: 2rem;
-  }
-
-  .site-menu summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .site-menu-panel {
-    background: #fff;
-    border: 1px solid var(--trovu-border);
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-    min-width: 12rem;
-    padding: 0.4rem 0;
-    position: absolute;
-    right: 0;
-    top: calc(100% + 0.4rem);
-    z-index: 10;
-  }
-
-  .site-menu-panel a {
-    color: #333;
-    display: block;
-    padding: 0.45rem 0.9rem;
-    white-space: nowrap;
   }
 
   .site-main {


### PR DESCRIPTION
## Summary
- replace the Eleventy starter blog shell with Trovu-style shared header and footer partials
- bundle Bootstrap into the blog CSS and restyle blog pages with the main-site colors, logo, tags, and footer/install links
- pass through the shared logo, OG image, manifest, and favicon assets for standalone blog builds

## Tests
- npm run build-blog
- npm run build
- git diff --check
- Playwright screenshots for desktop blog index and mobile post layout