### PR TITLE
Warn when a shortcut keyword contains a dot

### DIFF
--- a/src/ts/modules/NamespaceFetcher.test.ts
+++ b/src/ts/modules/NamespaceFetcher.test.ts
@@ -129,6 +129,29 @@ describe("NamespaceFetcher.processShortcuts", () => {
   });
 });
 
+describe("NamespaceFetcher.checkKeySyntax", () => {
+  test("keyword without dot", () => {
+    const logger = createLogger();
+    const shortcuts = { "foo 0": "https://example.com/" };
+    expect(new NamespaceFetcher({ logger }).checkKeySyntax(shortcuts, "testNamespace")).toEqual(shortcuts);
+    expect(logger.warning).not.toHaveBeenCalled();
+  });
+  test("keyword with dot", () => {
+    const logger = createLogger();
+    const shortcuts = { "creativecommons.org 0": "https://creativecommons.org/" };
+    expect(new NamespaceFetcher({ logger }).checkKeySyntax(shortcuts, "testNamespace")).toEqual(shortcuts);
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Incorrect keyword "creativecommons.org" in key "creativecommons.org 0" in namespace testNamespace: Must not contain a ".".',
+    );
+  });
+  test("dot only in namespace name", () => {
+    const logger = createLogger();
+    const shortcuts = { "foo 0": "https://example.com/" };
+    expect(new NamespaceFetcher({ logger }).checkKeySyntax(shortcuts, ".de")).toEqual(shortcuts);
+    expect(logger.warning).not.toHaveBeenCalled();
+  });
+});
+
 describe("NamespaceFetcher.addNamespaceInfo", () => {
   test("site", () => {
     const env = new Env();

--- a/src/ts/modules/NamespaceFetcher.ts
+++ b/src/ts/modules/NamespaceFetcher.ts
@@ -295,6 +295,15 @@ export default class NamespaceFetcher {
           `Incorrect key "${key}" in namespace ${namespaceName}: Must have form "KEYWORD ARGUMENTCOUNT".`,
         );
       }
+      // A dot in a keyword makes the shortcut unreachable:
+      // QueryParser.getExtraNamespace() splits the queried keyword at the dot
+      // and reads everything before it as a namespace name.
+      const keyword = key.split(" ")[0];
+      if (keyword.includes(".")) {
+        this.env.logger.warning(
+          `Incorrect keyword "${keyword}" in key "${key}" in namespace ${namespaceName}: Must not contain a ".".`,
+        );
+      }
     }
     return shortcuts;
   }


### PR DESCRIPTION
Closes #391.

`NamespaceFetcher.checkKeySyntax()` now emits a warning when the keyword part of a shortcut key contains a `.`. It is a warning rather than an error because `logger.error()` throws, and this condition already occurs in the site data.

Rationale for anyone reading later: `QueryParser.getExtraNamespace()` splits a queried keyword at the first dot and treats the part before it as a namespace name, so a shortcut whose keyword contains a dot can never be matched.

Three tests added in a new `describe("NamespaceFetcher.checkKeySyntax")` block — keyword with a dot warns, keyword without a dot does not, and a namespace *name* containing a dot (`.de`) does not. `npm run test-unit`: 138 passing. `npm run typecheck`: clean.

One thing this surfaced: `data/shortcuts/o.yml` defines `creativecommons.org 0` and `creativecommons.org 1`, and the new check warns on both. They appear to be genuinely unreachable for the reason above. I have deliberately not changed them — renaming a shortcut affects your users and is your call.

**Disclosure: the code in this pull request was written by an AI.** I read it, I ran the tests, and I am submitting it and answering for it here as a person. If that is not something you want in this repo, close it and no hard feelings — that is a legitimate answer.
