### PR TITLE
fix: open target URLs in browser tab when running as standalone PWA

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,21 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    if (env.isRunningStandalone()) {
+      // When installed as a PWA, open the target in a new browser tab/app so
+      // the PWA stays open. An anchor click (rather than window.open) triggers
+      // the browser's native link handling, which respects app associations
+      // (e.g. YouTube links opening in the YouTube app).
+      const link = document.createElement("a");
+      link.href = redirectUrl;
+      link.target = "_blank";
+      link.rel = "noopener";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } else {
+      window.location.replace(redirectUrl);
+    }
   }
 
   /**


### PR DESCRIPTION
/claim #329

## What this does

When trovU is installed as a PWA, `CallHandler.handleCall()` used `window.location.replace(redirectUrl)`, which navigates the **PWA window itself** to the target URL. The target therefore opens *inside* the PWA — no address bar, no tab switcher.

This PR changes that: when running as a standalone PWA, the target URL is opened via an anchor click with `target="_blank"` (and `rel="noopener"`), so the PWA stays open and the target opens in a new browser tab/app. Non-PWA contexts keep the existing `window.location.replace` behavior.

## Why an anchor click and not `window.open`

An anchor click triggers the browser's native link handling, which respects Android app associations (e.g. YouTube links opening in the YouTube app) — exactly what the issue requests. `window.open` does not reliably do this.

## Honest caveat about mobile

Per [web.dev](https://web.dev/learn/pwa/windows#forcing_a_browsers_navigation): *"If you want to force open the browser with a URL and not an in-app browser, you can use the `_blank` target of `<a href>` elements. **This works only on desktop PWAs. On mobile devices, there's no option to open a browser with a URL.**"*

So on Android this is a **platform limitation** — no code can force an external browser from a standalone PWA. This PR implements the documented best practice: it works on desktop, and on mobile it at least prevents the PWA from being navigated away (the target opens in the in-app browser instead of replacing the PWA).

## Validation

- `tsc --noEmit` → 0 errors
- `jest CallHandler` → 7/7 pass
- Uses the existing `Env.isRunningStandalone()` helper already present in the codebase

I am a human who is writing this comment, not an AI.