### PR TITLE
Open external redirects outside standalone PWA

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -51,6 +51,23 @@ describe("CallHandler", () => {
   test("isSafeRedirectUrl blocks unparseable URLs", () => {
     expect(CallHandler.isSafeRedirectUrl("not a url")).toBe(false);
   });
+  test("navigateToRedirectUrl opens external targets in a new context when running standalone", () => {
+    const anchor = document.createElement("a");
+    anchor.click = jest.fn();
+    const createElement = jest.spyOn(document, "createElement").mockReturnValue(anchor);
+
+    CallHandler.navigateToRedirectUrl("https://google.com/search?q=trovu", {
+      isRunningStandalone: () => true,
+    });
+
+    expect(createElement).toHaveBeenCalledWith("a");
+    expect(anchor.href).toBe("https://google.com/search?q=trovu");
+    expect(anchor.target).toBe("_blank");
+    expect(anchor.rel).toBe("noopener noreferrer");
+    expect(anchor.click).toHaveBeenCalledTimes(1);
+
+    createElement.mockRestore();
+  });
   test("getRedirectResponse returns suspicious for blocked redirect URLs", () => {
     const shortcutSpy = jest.spyOn(ShortcutFinder, "findShortcut").mockReturnValue({
       url: "javascript:alert(1)",

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -48,6 +48,19 @@ export default class CallHandler {
     window.location.replace(redirectUrl);
   }
 
+  static navigateToRedirectUrl(redirectUrl: string, env: Pick<Env, "isRunningStandalone">) {
+    if (env.isRunningStandalone() && this.isExternalHttpRedirectUrl(redirectUrl)) {
+      const link = document.createElement("a");
+      link.href = redirectUrl;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.click();
+      return;
+    }
+
+    window.location.href = redirectUrl;
+  }
+
   /**
    * Given the environment, get a response object, incl. redirect URL.
    *
@@ -130,6 +143,17 @@ export default class CallHandler {
       return false;
     }
     return ["http:", "https:", "mailto:"].includes(parsedUrl.protocol);
+  }
+
+  static isExternalHttpRedirectUrl(redirectUrl: string): boolean {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(redirectUrl);
+    } catch {
+      return false;
+    }
+
+    return ["http:", "https:"].includes(parsedUrl.protocol) && parsedUrl.origin !== window.location.origin;
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.navigateToRedirectUrl(redirectUrl, envQuery);
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
Fixes #329

This changes homepage query redirects in standalone PWA mode so external HTTP(S) targets are opened through a temporary `target="_blank"` anchor instead of replacing the current PWA window.

Why:
- The current homepage submit flow assigns `window.location.href` directly.
- In standalone PWA mode, that can keep external targets inside the installed app context.
- Opening external HTTP(S) targets with `target="_blank"` lets the browser handle them outside the current standalone app window.

Validation:
- npm run test