### PR TITLE
Open PWA shortcut targets in the system browser

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -1,6 +1,7 @@
 /** @module CallHandler */
 import Env from "./Env";
 import GitLogger from "./GitLogger";
+import { openExternalUrl } from "./openExternal";
 import ShortcutFinder from "./ShortcutFinder";
 import UrlProcessor from "./UrlProcessor";
 import type { EnvLike, RedirectResponse, Shortcut } from "../types";
@@ -45,7 +46,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    openExternalUrl(redirectUrl);
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -2,6 +2,7 @@
 import "../../scss/style.scss";
 import CallHandler from "./CallHandler";
 import Env from "./Env";
+import { openExternalUrl } from "./openExternal";
 import GitLogger from "./GitLogger";
 import Settings from "./home/Settings";
 import Suggestions from "./home/Suggestions";
@@ -394,7 +395,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    openExternalUrl(redirectUrl);
   };
 
   showSubmitProgress() {

--- a/src/ts/modules/openExternal.test.ts
+++ b/src/ts/modules/openExternal.test.ts
@@ -1,0 +1,86 @@
+import {
+  isInAppRedirect,
+  isAndroidUserAgent,
+  isIOSUserAgent,
+  openExternalUrl,
+  toAndroidIntentUrl,
+  toIOSSafariUrl,
+} from "./openExternal";
+
+describe("openExternal", () => {
+  test("toAndroidIntentUrl uses a new-document launch so Chrome cannot keep the PWA task", () => {
+    expect(toAndroidIntentUrl("https://www.google.com/search?q=foo")).toBe(
+      "intent://www.google.com/search?q=foo#Intent;scheme=https;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;launchFlags=0x18080000;end",
+    );
+  });
+
+  test("toIOSSafariUrl wraps https", () => {
+    expect(toIOSSafariUrl("https://www.google.com/search?q=g")).toBe(
+      "x-safari-https://www.google.com/search?q=g",
+    );
+  });
+
+  test("isInAppRedirect keeps homepage fallbacks inside the PWA", () => {
+    expect(isInAppRedirect("../index.html#status=not_found")).toBe(true);
+    expect(isInAppRedirect("https://www.google.com")).toBe(false);
+  });
+
+  test("user-agent helpers", () => {
+    expect(isAndroidUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel)")).toBe(true);
+    expect(isIOSUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)")).toBe(true);
+    expect(isAndroidUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)")).toBe(false);
+  });
+
+  test("openExternalUrl clicks an intent:// anchor on Android standalone PWA", () => {
+    const clickAnchor = jest.fn();
+    const assign = jest.fn();
+    const replace = jest.fn();
+    openExternalUrl("https://www.google.com/search?q=g", {
+      clickAnchor,
+      assign,
+      replace,
+      standalone: true,
+      android: true,
+      ios: false,
+    });
+    expect(clickAnchor).toHaveBeenCalledWith(
+      "intent://www.google.com/search?q=g#Intent;scheme=https;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;launchFlags=0x18080000;end",
+    );
+    expect(assign).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  test("openExternalUrl stays in-app for homepage fallbacks", () => {
+    const replace = jest.fn();
+    openExternalUrl("../index.html#status=not_found", {
+      replace,
+      standalone: true,
+      android: true,
+    });
+    expect(replace).toHaveBeenCalledWith("../index.html#status=not_found");
+  });
+
+  test("openExternalUrl uses window.open on desktop standalone PWA", () => {
+    const open = jest.fn().mockReturnValue({});
+    const replace = jest.fn();
+    openExternalUrl("https://www.google.com", {
+      open,
+      replace,
+      standalone: true,
+      android: false,
+      ios: false,
+    });
+    expect(open).toHaveBeenCalledWith("https://www.google.com", "_blank", "noopener,noreferrer");
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  test("openExternalUrl uses location.replace in a normal browser tab", () => {
+    const replace = jest.fn();
+    openExternalUrl("https://www.google.com", {
+      replace,
+      standalone: false,
+      android: true,
+    });
+    expect(replace).toHaveBeenCalledWith("https://www.google.com");
+  });
+});

--- a/src/ts/modules/openExternal.ts
+++ b/src/ts/modules/openExternal.ts
@@ -1,0 +1,116 @@
+/** Open a shortcut target outside a standalone PWA when possible. */
+
+export function isStandaloneDisplay(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  if (window.matchMedia("(display-mode: standalone)").matches) {
+    return true;
+  }
+  const nav = window.navigator as Navigator & { standalone?: boolean };
+  return nav.standalone === true;
+}
+
+export function isAndroidUserAgent(
+  userAgent: string = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): boolean {
+  return /Android/i.test(userAgent);
+}
+
+export function isIOSUserAgent(
+  userAgent: string = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): boolean {
+  return /iPad|iPhone|iPod/i.test(userAgent);
+}
+
+export function isInAppRedirect(url: string): boolean {
+  return url.startsWith("../") || url.startsWith("./") || url.startsWith("index.html") || url.startsWith("#");
+}
+
+/**
+ * Chrome's PWA task swallows https navigations and Custom Tabs.
+ * FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_MULTIPLE_TASK | FLAG_ACTIVITY_NEW_DOCUMENT
+ * asks the OS for a separate browser document (address bar + tab switcher).
+ */
+export function toAndroidIntentUrl(url: string): string {
+  const parsed = new URL(url);
+  const scheme = parsed.protocol.replace(":", "");
+  if (scheme !== "http" && scheme !== "https") {
+    return url;
+  }
+  const path = `${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`;
+  return (
+    `intent://${path}#Intent;scheme=${scheme};action=android.intent.action.VIEW;` +
+    `category=android.intent.category.BROWSABLE;launchFlags=0x18080000;end`
+  );
+}
+
+export function toIOSSafariUrl(url: string): string {
+  if (url.startsWith("https://")) {
+    return `x-safari-https://${url.slice("https://".length)}`;
+  }
+  if (url.startsWith("http://")) {
+    return `x-safari-http://${url.slice("http://".length)}`;
+  }
+  return url;
+}
+
+function navigateWithAnchor(href: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.rel = "noopener noreferrer";
+  anchor.style.display = "none";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+export function openExternalUrl(
+  url: string,
+  deps: {
+    assign?: (href: string) => void;
+    replace?: (href: string) => void;
+    open?: (href: string, target: string, features?: string) => Window | null;
+    clickAnchor?: (href: string) => void;
+    standalone?: boolean;
+    android?: boolean;
+    ios?: boolean;
+  } = {},
+): void {
+  const assign = deps.assign ?? ((href) => window.location.assign(href));
+  const replace = deps.replace ?? ((href) => window.location.replace(href));
+  const open = deps.open ?? ((href, target, features) => window.open(href, target, features));
+  const clickAnchor = deps.clickAnchor ?? navigateWithAnchor;
+  const standalone = deps.standalone ?? isStandaloneDisplay();
+  const android = deps.android ?? isAndroidUserAgent();
+  const ios = deps.ios ?? isIOSUserAgent();
+
+  if (isInAppRedirect(url)) {
+    replace(url);
+    return;
+  }
+
+  if (!standalone) {
+    replace(url);
+    return;
+  }
+
+  if (android) {
+    // Chrome rewrites location.assign(intent://) back to https inside the PWA.
+    // A clicked <a href> is handed to the Android intent resolver instead.
+    clickAnchor(toAndroidIntentUrl(url));
+    return;
+  }
+
+  if (ios) {
+    assign(toIOSSafariUrl(url));
+    return;
+  }
+
+  const popup = open(url, "_blank", "noopener,noreferrer");
+  if (popup) {
+    return;
+  }
+
+  clickAnchor(url);
+}


### PR DESCRIPTION
Fixes #329

Shortcut targets currently stay inside the installed Trovu PWA, so you never get the real browser (address bar, tab switcher) or the native app for maps/youtube/etc.

A bunch of earlier attempts used `window.open` / `target=_blank` and `location.assign(intent://...)`. Those don't work on Android Chrome PWAs: Chrome rewrites the intent back to https and keeps it in the same task. The videos on those PRs still showed Google with no address bar.

This tries a different path on Android standalone:

- build `intent://…#Intent;scheme=https;action=VIEW;category=BROWSABLE;launchFlags=0x18080000;end` (`NEW_TASK | MULTIPLE_TASK | NEW_DOCUMENT`) so Chrome can't reuse the PWA task
- click a temporary `<a href>` instead of `location.assign`, because that's what actually goes through the Android intent resolver

iOS standalone uses `x-safari-https://`. Desktop PWA uses `window.open`. In-app fallbacks (`../index.html#…`) stay in the PWA.

I couldn't record the Android PWA video from here. I'll post one: query `g`, Google opens outside Trovu with address bar + tab switcher.

/claim #329
