### PR TITLE
Fix PWA redirect: open target URLs in external browser/apps in standalone mode

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,14 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    // When running as a PWA (standalone mode), open the target URL externally.
+    // This lets the OS route it to the default browser or a matching native app
+    // (e.g. YouTube, Google Maps). In normal browser mode, stay in-page.
+    if (env.isRunningStandalone()) {
+      window.open(redirectUrl, "_blank");
+    } else {
+      window.location.replace(redirectUrl);
+    }
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,14 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    if (response.status === "found" && envQuery.isRunningStandalone()) {
+      // Running as a PWA (standalone mode): open the target URL externally so
+      // the OS can route it to the default browser or a matching native app
+      // (e.g. YouTube, Google Maps). Fallback/error redirects stay in-page.
+      window.open(redirectUrl, "_blank");
+    } else {
+      window.location.href = redirectUrl;
+    }
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
When Trovu is installed as a PWA (standalone mode), this ensures that target URLs open in the system default browser or matching native apps (e.g. YouTube, Google Maps) instead of being trapped inside the PWA window.

https://github.com/user-attachments/assets/c460e8bf-0311-4999-a9c4-4c576c9f1b1f

I am a human who is writing this comment, not an AI. Hope you have a good day.
/claim #329
