### PR TITLE
Open PWA targets with Android intent:// so they leave standalone

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -53,7 +53,7 @@ describe("CallHandler", () => {
   });
   test("toAndroidIntentUrl builds a VIEW intent for https", () => {
     expect(CallHandler.toAndroidIntentUrl("https://www.google.com/search?q=trovu")).toBe(
-      "intent://www.google.com/search?q=trovu#Intent;scheme=https;action=android.intent.action.VIEW;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dtrovu;end",
+      "intent://www.google.com/search?q=trovu#Intent;scheme=https;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;launchFlags=0x10000000;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dtrovu;end",
     );
   });
   test("toAndroidIntentUrl leaves non-http URLs unchanged", () => {

--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -51,6 +51,14 @@ describe("CallHandler", () => {
   test("isSafeRedirectUrl blocks unparseable URLs", () => {
     expect(CallHandler.isSafeRedirectUrl("not a url")).toBe(false);
   });
+  test("toAndroidIntentUrl builds a VIEW intent for https", () => {
+    expect(CallHandler.toAndroidIntentUrl("https://www.google.com/search?q=trovu")).toBe(
+      "intent://www.google.com/search?q=trovu#Intent;scheme=https;action=android.intent.action.VIEW;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dtrovu;end",
+    );
+  });
+  test("toAndroidIntentUrl leaves non-http URLs unchanged", () => {
+    expect(CallHandler.toAndroidIntentUrl("mailto:test@example.com")).toBe("mailto:test@example.com");
+  });
   test("getRedirectResponse returns suspicious for blocked redirect URLs", () => {
     const shortcutSpy = jest.spyOn(ShortcutFinder, "findShortcut").mockReturnValue({
       url: "javascript:alert(1)",

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -96,7 +96,9 @@ export default class CallHandler {
     const scheme = parsed.protocol.replace(":", "");
     const path = `${parsed.host}${parsed.pathname}${parsed.search}`;
     const fallback = encodeURIComponent(url);
-    return `intent://${path}#Intent;scheme=${scheme};action=android.intent.action.VIEW;S.browser_fallback_url=${fallback};end`;
+    // NEW_TASK (0x10000000) starts Chrome in its own task so the PWA does not swallow the tab.
+    // BROWSABLE is what the OS uses for "open this URL in a browser".
+    return `intent://${path}#Intent;scheme=${scheme};action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;launchFlags=0x10000000;S.browser_fallback_url=${fallback};end`;
   }
 
   /**

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,58 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.openTargetUrl(redirectUrl, env);
+  }
+
+  /**
+   * Leave a standalone PWA so the OS can open the default browser or a native app.
+   * Android Chrome keeps https navigations inside the PWA; an intent:// VIEW does not.
+   * In-app fallbacks (home, errors) stay inside the PWA.
+   */
+  static openTargetUrl(redirectUrl: string, env: { isRunningStandalone?: () => boolean }) {
+    const standalone = typeof env.isRunningStandalone === "function" && env.isRunningStandalone();
+    const staysInPwa =
+      redirectUrl.startsWith("../") ||
+      redirectUrl.startsWith("index.html") ||
+      redirectUrl.startsWith("./") ||
+      redirectUrl.startsWith("#");
+
+    if (!standalone || staysInPwa) {
+      window.location.replace(redirectUrl);
+      return;
+    }
+
+    if (redirectUrl.startsWith("mailto:")) {
+      window.location.href = redirectUrl;
+      return;
+    }
+
+    if (/Android/i.test(navigator.userAgent || "")) {
+      window.location.href = this.toAndroidIntentUrl(redirectUrl);
+      return;
+    }
+
+    const opened = window.open(redirectUrl, "_blank", "noopener,noreferrer");
+    if (!opened) {
+      window.location.href = redirectUrl;
+    }
+  }
+
+  /** Android Intent URL that asks the OS to VIEW this http(s) address outside the PWA. */
+  static toAndroidIntentUrl(url: string): string {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return url;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return url;
+    }
+    const scheme = parsed.protocol.replace(":", "");
+    const path = `${parsed.host}${parsed.pathname}${parsed.search}`;
+    const fallback = encodeURIComponent(url);
+    return `intent://${path}#Intent;scheme=${scheme};action=android.intent.action.VIEW;S.browser_fallback_url=${fallback};end`;
   }
 
   /**

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    CallHandler.openTargetUrl(redirectUrl, envQuery);
   };
 
   showSubmitProgress() {


### PR DESCRIPTION
Fixes #329

window.open and target=_blank keep https URLs inside Chrome's standalone PWA on Android 14. That is why the existing PRs still fail on the maintainer's device.

This change only applies when the app is in standalone mode and the redirect is an external http(s) URL:

- Android: intent:// VIEW so the OS opens the default browser or a registered app (Maps, YouTube).
- Other platforms: window.open with a same-window fallback.
- Home/error redirects stay inside the PWA.

/claim #329