### PR TITLE
Fix PWA redirect: open target URLs externally

### DIFF
--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -4,7 +4,7 @@ import GitLogger from "./GitLogger";
 import ShortcutFinder from "./ShortcutFinder";
 import UrlProcessor from "./UrlProcessor";
 import type { EnvLike, RedirectResponse, Shortcut } from "../types";
-
+import { appConfigs, AppConfig } from "../types";
 /** Handle a call. */
 
 export default class CallHandler {
@@ -151,4 +151,48 @@ export default class CallHandler {
     const redirectUrl = "../index.html#" + paramStr;
     return redirectUrl;
   }
+   static transformUrl(url: string): string {
+  // 📱 
+  const ua = navigator.userAgent;
+  const isMobile = /Android|iPhone|iPod|BlackBerry|Windows Phone|Opera Mini|IEMobile|Mobile/i.test(ua);
+  
+  // 💻 
+  if (!isMobile) {
+    return url;
+  }
+  
+  // 📱
+  for (const config of Object.values(appConfigs) as AppConfig[]) {
+    if (config.regex.test(url)) {
+      if (config.isMaps) {
+        // Maps
+        let match = url.match(/@(-?\d+\.\d+),(-?\d+\.\d+)/);
+        if (match) return `${config.prefix}${match[1]},${match[2]}`;
+        
+        match = url.match(/place\/([^/]+)/);
+        if (match) return `${config.prefix}${decodeURIComponent(match[1])}`;
+        
+        match = url.match(/[?&]q=([^&]+)/);
+        if (match) return `${config.prefix}${decodeURIComponent(match[1])}`;
+        
+        match = url.match(/[?&]dir=([^&]+)/);
+        if (match) return `${config.prefix}${decodeURIComponent(match[1])}`;
+        
+        return config.prefix;
+      }
+      
+      return url.indexOf(config.prefix) === 0 ? url : config.prefix +  url.replace(/^https?:\/\//, '');
+    }
+  }
+  
+  
+  if (/Android/.test(ua)) return `intent:${url}#Intent;end;`;
+  if (/iPad|iPhone|iPod/.test(ua)) return `x-web-search://${url}`;
+  
+  //global fallback for other mobile devices
+  return url;
 }
+
+}
+
+

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -394,7 +394,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    window.location.href = CallHandler.transformUrl(redirectUrl); 
   };
 
   showSubmitProgress() {

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -248,3 +248,68 @@ export interface SettingsOption {
   name: string;
   emoji?: string;
 }
+export interface AppConfig {
+    prefix: string;
+    regex: RegExp;
+    isMaps?: boolean;
+    appType?: string;
+}
+
+export const appConfigs: { [key: string]: AppConfig } = {
+    maps: { 
+        prefix: 'geo:', 
+        regex: /(maps\.google\.com|google\.com\/maps|goo\.gl\/maps)/i, 
+        isMaps: true,
+        appType: 'maps'
+    },
+    youtube: { 
+        prefix: 'vnd.youtube://', 
+        regex: /(youtube\.com|youtu\.be)/i,
+        appType: 'youtube'
+    },
+    spotify: { 
+        prefix: 'spotify://', 
+        regex: /spotify\.com/i,
+        appType: 'spotify'
+    },
+    github: { 
+        prefix: 'ghapp://', 
+        regex: /github\.com/i,
+        appType: 'github'
+    },
+    facebook: { 
+        prefix: 'fb://', 
+        regex: /(facebook\.com|fb\.com)/i,
+        appType: 'facebook'
+    },
+    instagram: { 
+        prefix: 'instagram://', 
+        regex: /instagram\.com/i,
+        appType: 'instagram'
+    },
+    twitter: { 
+        prefix: 'twitter://', 
+        regex: /(twitter\.com|x\.com)/i,
+        appType: 'twitter'
+    },
+    whatsapp: { 
+        prefix: 'whatsapp://', 
+        regex: /(whatsapp\.com|wa\.me)/i,
+        appType: 'whatsapp'
+    },
+    linkedin: { 
+        prefix: 'linkedin://', 
+        regex: /linkedin\.com/i,
+        appType: 'linkedin'
+    },
+    reddit: { 
+        prefix: 'reddit://', 
+        regex: /reddit\.com/i,
+        appType: 'reddit'
+    },
+    tiktok: { 
+        prefix: 'tiktok://', 
+        regex: /tiktok\.com/i,
+        appType: 'tiktok'
+    }
+};


### PR DESCRIPTION
Fixes https://github.com/trovu/trovu/issues/329
Objective: Ensure links open in the default browser on both Android and iOS.
Approach: Use deep links such as "mailto://", "geo://", and "vnd.youtube://".
Concatenate them to the query and redirect.
Intents are used for Android devices, while "x-web-search" is used for iOS; this guarantees the default browser opens in both cases. Additionally, fallback mechanisms were added to handle scenarios where the specific device/app is not found.


video: 
<video src="https://github.com/user-attachments/assets/e2a9ba15-b4dd-459b-b7a5-2bc12c725248" width="100%" controls autoplay loop muted></video>






I am a human who is writing this comment, not an AI.
/claim https://github.com/trovu/trovu/issues/329