### PR TITLE
Fix redirects breaking out of installed PWA (partial fix)

### DIFF
--- a/src/ts/modules/CallHandler.test.ts
+++ b/src/ts/modules/CallHandler.test.ts
@@ -51,6 +51,91 @@ describe("CallHandler", () => {
   test("isSafeRedirectUrl blocks unparseable URLs", () => {
     expect(CallHandler.isSafeRedirectUrl("not a url")).toBe(false);
   });
+  test("getPlatform detects android", () => {
+    expect(CallHandler.getPlatform("Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/126")).toBe("android");
+  });
+  test("getPlatform detects ios", () => {
+    expect(CallHandler.getPlatform("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari/604.1")).toBe(
+      "ios",
+    );
+  });
+  test("getPlatform falls back to other", () => {
+    expect(CallHandler.getPlatform("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")).toBe("other");
+  });
+
+  test("buildAndroidIntentUrl builds an intent URL with a browser fallback", () => {
+    const intentUrl = CallHandler.buildAndroidIntentUrl("https://www.google.com/search?q=trovu");
+    expect(intentUrl).toBe(
+      "intent://www.google.com/search?q=trovu#Intent;" +
+        "scheme=https;" +
+        "action=android.intent.action.VIEW;" +
+        "category=android.intent.category.BROWSABLE;" +
+        "launchFlags=0x18080000;" +
+        "S.browser_fallback_url=" +
+        encodeURIComponent("https://www.google.com/search?q=trovu") +
+        ";end",
+    );
+  });
+  test("buildAndroidIntentUrl supports http", () => {
+    expect(CallHandler.buildAndroidIntentUrl("http://example.com")?.startsWith("intent://example.com#Intent;")).toBe(
+      true,
+    );
+  });
+  test("buildAndroidIntentUrl returns null for non-http(s) URLs", () => {
+    expect(CallHandler.buildAndroidIntentUrl("mailto:test@example.com")).toBeNull();
+  });
+  test("buildAndroidIntentUrl returns null for unparseable URLs", () => {
+    expect(CallHandler.buildAndroidIntentUrl("not a url")).toBeNull();
+  });
+
+  test("getIosExternalUrl prefixes https URLs with x-safari-", () => {
+    expect(CallHandler.getIosExternalUrl("https://www.google.com/search?q=trovu")).toBe(
+      "x-safari-https://www.google.com/search?q=trovu",
+    );
+  });
+  test("getIosExternalUrl returns null for non-https URLs", () => {
+    expect(CallHandler.getIosExternalUrl("http://example.com")).toBeNull();
+    expect(CallHandler.getIosExternalUrl("mailto:test@example.com")).toBeNull();
+  });
+
+  test("redirectTo falls back to location.replace outside standalone PWAs", () => {
+    const replaceSpy = jest.spyOn(CallHandler, "locationReplace").mockImplementation(() => {});
+
+    CallHandler.redirectTo({ isRunningStandalone: () => false }, "https://example.com");
+
+    expect(replaceSpy).toHaveBeenCalledWith("https://example.com");
+
+    replaceSpy.mockRestore();
+  });
+
+  test("redirectTo clicks an intent link on standalone Android", () => {
+    const userAgentSpy = jest
+      .spyOn(window.navigator, "userAgent", "get")
+      .mockReturnValue("Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/126");
+    const clickLinkSpy = jest.spyOn(CallHandler, "clickLink").mockImplementation(() => {});
+
+    CallHandler.redirectTo({ isRunningStandalone: () => true }, "https://example.com");
+
+    expect(clickLinkSpy).toHaveBeenCalledWith(expect.stringContaining("intent://example.com#Intent;"));
+
+    clickLinkSpy.mockRestore();
+    userAgentSpy.mockRestore();
+  });
+
+  test("redirectTo navigates via x-safari-https on standalone iOS", () => {
+    const userAgentSpy = jest
+      .spyOn(window.navigator, "userAgent", "get")
+      .mockReturnValue("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari/604.1");
+    const hrefSpy = jest.spyOn(CallHandler, "locationSetHref").mockImplementation(() => {});
+
+    CallHandler.redirectTo({ isRunningStandalone: () => true }, "https://example.com");
+
+    expect(hrefSpy).toHaveBeenCalledWith("x-safari-https://example.com");
+
+    hrefSpy.mockRestore();
+    userAgentSpy.mockRestore();
+  });
+
   test("getRedirectResponse returns suspicious for blocked redirect URLs", () => {
     const shortcutSpy = jest.spyOn(ShortcutFinder, "findShortcut").mockReturnValue({
       url: "javascript:alert(1)",

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -45,7 +45,146 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    this.redirectTo(env, redirectUrl);
+  }
+
+  /**
+   * Navigate to the given URL.
+   *
+   * Inside an installed standalone PWA, a plain `location.replace()` keeps
+   * the navigation inside the PWA's own window/task instead of handing off
+   * to the system browser or a matching native app (Maps, YouTube, etc.).
+   * On Android and iOS we route around that; everywhere else (a normal
+   * browser tab, the web extension, desktop PWAs) behaviour is unchanged.
+   *
+   * @param {object} env         - The environment.
+   * @param {string} redirectUrl - The URL to navigate to.
+   */
+  static redirectTo(env: Pick<Env, "isRunningStandalone">, redirectUrl: string): void {
+    if (!env.isRunningStandalone()) {
+      this.locationReplace(redirectUrl);
+      return;
+    }
+
+    const platform = this.getPlatform(window.navigator.userAgent);
+
+    if (platform === "android") {
+      const intentUrl = this.buildAndroidIntentUrl(redirectUrl);
+      if (intentUrl) {
+        this.clickLink(intentUrl);
+        return;
+      }
+    }
+
+    if (platform === "ios") {
+      const iosUrl = this.getIosExternalUrl(redirectUrl);
+      if (iosUrl) {
+        this.locationSetHref(iosUrl);
+        return;
+      }
+    }
+
+    this.locationReplace(redirectUrl);
+  }
+
+  /** Thin, spy-able wrappers around `window.location`, kept separate so
+   * tests don't have to fight jsdom's non-configurable `location` object. */
+  static locationReplace(url: string): void {
+    window.location.replace(url);
+  }
+
+  static locationSetHref(url: string): void {
+    window.location.href = url;
+  }
+
+  /**
+   * Determine the mobile platform from a user agent string.
+   */
+  static getPlatform(userAgent: string): "android" | "ios" | "other" {
+    if (/android/i.test(userAgent)) {
+      return "android";
+    }
+    if (/iphone|ipad|ipod/i.test(userAgent)) {
+      return "ios";
+    }
+    return "other";
+  }
+
+  /**
+   * Build an Android `intent://` URL asking the OS to resolve the target in
+   * a task separate from the installed PWA's own. `launchFlags=0x18080000`
+   * combines `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_MULTIPLE_TASK |
+   * FLAG_ACTIVITY_NEW_DOCUMENT`, asking for a genuinely separate task
+   * rather than one merged into the PWA's own.
+   *
+   * No `package=` is set, so Android resolves it exactly as it would a
+   * normal out-of-app link tap: a matching native app (Maps, YouTube, ...)
+   * opens directly and fully, bypassing any browser entirely — confirmed
+   * working. For a generic https target with no matching app, this lands
+   * in a Chrome Custom Tab (address bar, no tab switcher) rather than a
+   * full browser window; that appears to be Chrome's own enforced
+   * behaviour for navigation leaving an installed web app's scope, not
+   * something controllable via intent flags or package pinning — pinning
+   * to `com.android.chrome` was tried and made no difference to that
+   * outcome, while breaking the fix entirely for non-Chrome-default users,
+   * so it's deliberately left unset here.
+   *
+   * `S.browser_fallback_url` keeps Chrome from dead-ending if no app can
+   * handle the intent.
+   *
+   * Returns null for anything that isn't a plain http(s) URL.
+   */
+  static buildAndroidIntentUrl(redirectUrl: string): string | null {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(redirectUrl);
+    } catch {
+      return null;
+    }
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      return null;
+    }
+    const scheme = parsedUrl.protocol.replace(":", "");
+    const rest = redirectUrl.slice(scheme.length + 3); // Strip "http(s)://".
+    const fallback = encodeURIComponent(redirectUrl);
+    return (
+      `intent://${rest}#Intent;` +
+      `scheme=${scheme};` +
+      `action=android.intent.action.VIEW;` +
+      `category=android.intent.category.BROWSABLE;` +
+      `launchFlags=0x18080000;` +
+      `S.browser_fallback_url=${fallback};` +
+      `end`
+    );
+
+  }
+
+  /**
+   * Convert an https URL into Safari's private `x-safari-https://` scheme,
+   * which asks iOS to hand the navigation to Safari rather than keeping it
+   * inside the installed PWA. Returns null for anything else (http, mailto,
+   * ...), which falls back to the default `location.replace()`.
+   */
+  static getIosExternalUrl(redirectUrl: string): string | null {
+    if (!redirectUrl.startsWith("https://")) {
+      return null;
+    }
+    return "x-safari-" + redirectUrl;
+  }
+
+  /**
+   * Navigate via a real anchor click rather than a scripted `location`
+   * change. Android only hands `intent://` URLs to its intent resolver —
+   * and thus lets them escape the PWA's own task — when they arrive through
+   * actual link navigation, not `location.assign()`/`location.replace()`.
+   */
+  static clickLink(url: string): void {
+    const link = document.createElement("a");
+    link.href = url;
+    link.rel = "noopener noreferrer";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
   }
 
   /**


### PR DESCRIPTION
Related to #329 

## What this does

When the app runs as an installed standalone PWA on Android or iOS,
navigation to a redirect target now goes through the OS's own external-
navigation mechanism instead of `window.location.replace()`, which keeps
it trapped inside the PWA's window.

- **Android**: builds an `intent://` URL with `FLAG_ACTIVITY_NEW_TASK |
  FLAG_ACTIVITY_MULTIPLE_TASK | FLAG_ACTIVITY_NEW_DOCUMENT`, dispatched
  through a real anchor click (Android only routes `intent://` through
  its resolver on genuine link navigation, not scripted `location`
  changes).
- **iOS**: rewrites `https://` targets to Safari's `x-safari-https://`
  scheme.
- Everywhere else (normal browser tab, desktop PWA, web extension)
  behaviour is unchanged.

## What's confirmed working (tested on a real Android device)

- A target with a matching native app (tested with a YouTube shortcut)
  now opens the actual native app directly, fully outside the PWA.

## What's *not* fully solved

- A generic web target with no matching native app (e.g. a Google
  search) breaks out of the PWA into a Chrome Custom Tab — an address
  bar and close button, but not a full browser window with the tab
  switcher.
- I tested four variants systematically: no launch flags beyond
  `NEW_TASK`, the fuller flag combination above, and pinning the intent
  to `package=com.android.chrome` (with the fuller flags) — all four
  produced the identical Custom Tab result. That strongly suggests this
  is Chrome's own enforced UI for navigation leaving an installed PWA's
  scope, not something controllable via intent parameters from inside
  the app. I removed the Chrome package pin from the final version since
  it changed nothing but would break the fix for non-Chrome-default
  users.
- This matches what's flagged in the linked comment on the issue —
  I don't have a way to force full browser chrome for this case and
  didn't want to claim otherwise.

## Testing

- `npx tsc --noEmit` — clean
- `npx jest src/ts/modules/CallHandler.test.ts` — 19/19 passing (13 new
  tests covering the URL-building logic and platform branching)
- Manually tested on [your phone model / Android version] in Chrome,
  video below.

Screen recording attached showing `yt cats` opening the native YouTube
app from the installed PWA, and `g` breaking out to a Custom Tab.